### PR TITLE
Add get_params() and set_params() to QKRR

### DIFF
--- a/src/squlearn/kernel/matrix/fidelity_kernel.py
+++ b/src/squlearn/kernel/matrix/fidelity_kernel.py
@@ -134,7 +134,7 @@ class FidelityKernel(KernelMatrixBase):
         params["evaluate_duplicates"] = self._evaluate_duplicates
         params["mit_depol_noise"] = self._mit_depol_noise
         if deep:
-            #params = self._feature_map.get_params()
+            # params = self._feature_map.get_params()
             params.update(self._feature_map.get_params())
         return params
 

--- a/src/squlearn/kernel/matrix/fidelity_kernel.py
+++ b/src/squlearn/kernel/matrix/fidelity_kernel.py
@@ -134,7 +134,8 @@ class FidelityKernel(KernelMatrixBase):
         params["evaluate_duplicates"] = self._evaluate_duplicates
         params["mit_depol_noise"] = self._mit_depol_noise
         if deep:
-            params = self._feature_map.get_params()
+            #params = self._feature_map.get_params()
+            params.update(self._feature_map.get_params())
         return params
 
     def set_params(self, **params):

--- a/src/squlearn/kernel/matrix/fidelity_kernel.py
+++ b/src/squlearn/kernel/matrix/fidelity_kernel.py
@@ -44,7 +44,7 @@ class FidelityKernel(KernelMatrixBase):
             FQKs computed on a real backend.
         regularization  (Union[str, None], default=None) :
             Option for choosing different regularization techniques ('thresholding' or 'tikhonov')
-            after Ref. [3] for the training kernel matrix, prior to  solving the linear system
+            after Ref. [4] for the training kernel matrix, prior to  solving the linear system
             in the ``fit()``-procedure.
 
     References:

--- a/src/squlearn/kernel/matrix/projected_quantum_kernel.py
+++ b/src/squlearn/kernel/matrix/projected_quantum_kernel.py
@@ -526,8 +526,9 @@ class ProjectedQuantumKernel(KernelMatrixBase):
 
         # Set outer kernel parameters
         dict_outer_kernel = {}
+        valid_keys_outer_kernel = self._outer_kernel.get_params().keys()
         for key, value in params.items():
-            if key in self._outer_kernel.get_params().keys():
+            if key in valid_keys_outer_kernel:
                 dict_outer_kernel[key] = value
         if len(dict_outer_kernel) > 0:
             self._outer_kernel.set_params(**dict_outer_kernel)
@@ -567,7 +568,7 @@ class GaussianOuterKernel(OuterKernelBase):
 
     def __init__(self, gamma=1.0):
         super().__init__()
-        self._gamma = gamma
+        self.gamma = gamma
         self._num_hyper_parameters = 1
         self._name_hyper_parameters = ["gamma"]
 
@@ -595,7 +596,7 @@ class GaussianOuterKernel(OuterKernelBase):
         else:
             y_result = None
 
-        return RBF(length_scale=1.0 / np.sqrt(2.0 * self._gamma))(x_result, y_result)
+        return RBF(length_scale=1.0 / np.sqrt(2.0 * self.gamma))(x_result, y_result)
 
     def get_params(self, deep: bool = True) -> dict:
         """
@@ -608,7 +609,7 @@ class GaussianOuterKernel(OuterKernelBase):
         Return:
             Dictionary with hyper-parameters and values.
         """
-        return {"gamma": self._gamma}
+        return {"gamma": self.gamma}
 
     def set_params(self, **params) -> None:
         """

--- a/src/squlearn/kernel/matrix/projected_quantum_kernel.py
+++ b/src/squlearn/kernel/matrix/projected_quantum_kernel.py
@@ -488,7 +488,8 @@ class ProjectedQuantumKernel(KernelMatrixBase):
                     self._executor,
                     self._measurement_input,
                     self._outer_kernel,
-                    self._parameters,
+                    #self._parameters,
+                    None
                 )
             else:
                 self._qnn.set_params(**dict_qnn)
@@ -503,7 +504,8 @@ class ProjectedQuantumKernel(KernelMatrixBase):
                 self._executor,
                 self._measurement_input,
                 self._outer_kernel,
-                self._parameters,
+                #self._parameters,
+                None
             )
 
         # Set QNN parameters

--- a/src/squlearn/kernel/matrix/projected_quantum_kernel.py
+++ b/src/squlearn/kernel/matrix/projected_quantum_kernel.py
@@ -278,7 +278,7 @@ class ProjectedQuantumKernel(KernelMatrixBase):
         * `sklean kernels <https://scikit-learn.org/stable/modules/gaussian_process.html#gp-kernels>`_
 
     References:
-        [1] Huang, HY., Broughton, M., Mohseni, M. et al., "Power of data in quantum machine learning", 
+        [1] Huang, HY., Broughton, M., Mohseni, M. et al., "Power of data in quantum machine learning",
         `Nat Commun 12, 2631 (2021). <https://doi.org/10.1038/s41467-021-22539-9>`_
 
         [2] T. Hubregtsen et al., "Training Quantum Embedding Kernels on Near-Term Quantum Computers",
@@ -527,10 +527,17 @@ class ProjectedQuantumKernel(KernelMatrixBase):
         # Set outer kernel parameters
         dict_outer_kernel = {}
         for key, value in params.items():
-            if key in self._outer_kernel.get_params():
+            if key in self._outer_kernel.get_params().keys():
                 dict_outer_kernel[key] = value
         if len(dict_outer_kernel) > 0:
             self._outer_kernel.set_params(**dict_outer_kernel)
+            self.__init__(
+                self._feature_map,
+                self._executor,
+                self._measurement_input,
+                self._outer_kernel,
+                None,
+            )
 
         self._parameters = None
         if self.num_parameters == num_parameters_backup:

--- a/src/squlearn/kernel/matrix/projected_quantum_kernel.py
+++ b/src/squlearn/kernel/matrix/projected_quantum_kernel.py
@@ -166,7 +166,7 @@ class ProjectedQuantumKernel(KernelMatrixBase):
     The expectation values are than used as features for the classical kernel, for which
     the different implementations of sklearn's kernels can be used.
 
-    The implementation is based on the paper https://doi.org/10.1038/s41467-021-22539-9
+    The implementation is based on Ref. [1].
 
     As defaults, a Gaussian outer kernel and the expectation value of all three Pauli matrices
     :math:`\{\hat{X},\hat{Y},\hat{Z}\}` are computed for every qubit.
@@ -185,7 +185,7 @@ class ProjectedQuantumKernel(KernelMatrixBase):
             operator (if parameterized)
         regularization  (Union[str, None], default=None) :
             Option for choosing different regularization techniques ('thresholding' or 'tikhonov')
-            after Ref. [3] for the training kernel matrix, prior to  solving the linear system
+            after Ref. [2] for the training kernel matrix, prior to  solving the linear system
             in the ``fit()``-procedure.
 
 
@@ -278,9 +278,11 @@ class ProjectedQuantumKernel(KernelMatrixBase):
         * `sklean kernels <https://scikit-learn.org/stable/modules/gaussian_process.html#gp-kernels>`_
 
     References:
-        * Huang, HY., Broughton, M., Mohseni, M. et al.
-          Power of data in quantum machine learning. Nat Commun 12, 2631 (2021).
-          https://doi.org/10.1038/s41467-021-22539-9
+        [1] Huang, HY., Broughton, M., Mohseni, M. et al., "Power of data in quantum machine learning", 
+        `Nat Commun 12, 2631 (2021). <https://doi.org/10.1038/s41467-021-22539-9>`_
+
+        [2] T. Hubregtsen et al., "Training Quantum Embedding Kernels on Near-Term Quantum Computers",
+        `arXiv:2105.02276v1 (2021). <https://arxiv.org/pdf/2105.02276.pdf>`_
 
     **Example: Calculate a kernel matrix with the Projected Quantum Kernel**
 

--- a/src/squlearn/kernel/ml/qkrr.py
+++ b/src/squlearn/kernel/ml/qkrr.py
@@ -80,6 +80,7 @@ class QKRR(BaseEstimator, RegressorMixin):
         quantum_kernel: Optional[KernelMatrixBase] = None,
         alpha: Union[float, np.ndarray] = 1.0e-6,
         regularize: Union[str, None] = None,
+        **kwargs
     ) -> None:
         self._quantum_kernel = quantum_kernel  # May be worth to set FQK as default here?
         self.alpha = alpha
@@ -88,7 +89,7 @@ class QKRR(BaseEstimator, RegressorMixin):
         self.k_testtrain = None
         self.k_train = None
         self.dual_coeff_ = None
-        self.num_qubits = self._quantum_kernel.num_qubits
+        #self.num_qubits = self._quantum_kernel.num_qubits
 
     def fit(self, x_train: np.ndarray, y_train: np.ndarray):
         """
@@ -148,16 +149,34 @@ class QKRR(BaseEstimator, RegressorMixin):
     # All scikit-learn estimators have get_params and set_params
     # (cf. https://scikit-learn.org/stable/developers/develop.html)
     def get_params(self, deep: bool = True):
-        return {
-            "quantum_kernel": self._quantum_kernel,
-            "alpha": self.alpha,
-            "regularize": self._regularize,
-        }
+        params = dict()
+        params["quantum_kernel"] = self._quantum_kernel
+        if deep:
+            params.update(self._quantum_kernel.get_params(deep=True))
+        else:
+            params.update(self._quantum_kernel.get_params(deep=False))
+        #params["num_qubits"] = self.num_qubits
+        params["alpha"] = self.alpha
+        # return {
+        #     "quantum_kernel": self._quantum_kernel,
+        #     "alpha": self.alpha,
+        #     "regularize": self._regularize,
+        # }
+        return params
 
-    def set_params(self, **parameters):
-        for parameter, value in parameters.items():
-            setattr(self, parameter, value)
-        return self
+    def set_params(self, **kwargs):
+        valid_params = self.get_params(deep=True)
+        param_dict = {}
+        for key, value in kwargs.items():
+            if key in valid_params:
+                param_dict[key] = value
+                self._quantum_kernel.set_params(**param_dict)
+        #return self
+
+    # def set_params(self, **parameters):
+    #     for parameter, value in parameters.items():
+    #         setattr(self, parameter, value)
+    #     return self
 
 
 ######

--- a/src/squlearn/kernel/ml/qkrr.py
+++ b/src/squlearn/kernel/ml/qkrr.py
@@ -142,9 +142,16 @@ class QKRR(BaseEstimator, RegressorMixin):
 
     def set_params(self, **params):
         valid_params = self.get_params()
+        for key, value in params.items():
+            if key not in valid_params:
+                raise ValueError(
+                    f"Invalid parameter {key!r}. "
+                    f"Valid parameters are {sorted(valid_params)!r}."
+                )
+
         param_dict = {}
         for key, value in params.items():
-            #if key in valid_params:
+            # if key in valid_params:
             if key in self._quantum_kernel.get_params().keys():
                 param_dict[key] = value
         self._quantum_kernel.set_params(**param_dict)
@@ -152,9 +159,6 @@ class QKRR(BaseEstimator, RegressorMixin):
         if "alpha" in params.keys():
             self.alpha = params["alpha"]
 
-        self.__init__(
-            self._quantum_kernel,
-            self.alpha
-        )
-        
+        self.__init__(self._quantum_kernel, self.alpha)
+
         return self

--- a/src/squlearn/kernel/ml/qkrr.py
+++ b/src/squlearn/kernel/ml/qkrr.py
@@ -40,8 +40,6 @@ class QKRR(BaseEstimator, RegressorMixin):
 
         [2] https://en.wikipedia.org/wiki/Ridge_regression
 
-        [3] T. Hubregtsen et al., "Training Quantum Embedding Kernels on Near-Term Quantum Computers",
-        `arXiv:2105.02276v1 (2021) <https://arxiv.org/pdf/2105.02276.pdf>`_.
 
     **Example**
 

--- a/src/squlearn/kernel/ml/qkrr.py
+++ b/src/squlearn/kernel/ml/qkrr.py
@@ -80,7 +80,7 @@ class QKRR(BaseEstimator, RegressorMixin):
         quantum_kernel: Optional[KernelMatrixBase] = None,
         alpha: Union[float, np.ndarray] = 1.0e-6,
         regularize: Union[str, None] = None,
-        **kwargs
+        **kwargs,
     ) -> None:
         self._quantum_kernel = quantum_kernel  # May be worth to set FQK as default here?
         self.alpha = alpha
@@ -89,7 +89,7 @@ class QKRR(BaseEstimator, RegressorMixin):
         self.k_testtrain = None
         self.k_train = None
         self.dual_coeff_ = None
-        #self.num_qubits = self._quantum_kernel.num_qubits
+        # self.num_qubits = self._quantum_kernel.num_qubits
 
     def fit(self, x_train: np.ndarray, y_train: np.ndarray):
         """
@@ -165,12 +165,7 @@ class QKRR(BaseEstimator, RegressorMixin):
             if key in valid_params:
                 param_dict[key] = value
                 self._quantum_kernel.set_params(**param_dict)
-        #return self
-
-    # def set_params(self, **parameters):
-    #     for parameter, value in parameters.items():
-    #         setattr(self, parameter, value)
-    #     return self
+        return self
 
 
 ######

--- a/src/squlearn/kernel/ml/qkrr.py
+++ b/src/squlearn/kernel/ml/qkrr.py
@@ -155,19 +155,13 @@ class QKRR(BaseEstimator, RegressorMixin):
             params.update(self._quantum_kernel.get_params(deep=True))
         else:
             params.update(self._quantum_kernel.get_params(deep=False))
-        #params["num_qubits"] = self.num_qubits
         params["alpha"] = self.alpha
-        # return {
-        #     "quantum_kernel": self._quantum_kernel,
-        #     "alpha": self.alpha,
-        #     "regularize": self._regularize,
-        # }
         return params
 
-    def set_params(self, **kwargs):
+    def set_params(self, **params):
         valid_params = self.get_params(deep=True)
         param_dict = {}
-        for key, value in kwargs.items():
+        for key, value in params.items():
             if key in valid_params:
                 param_dict[key] = value
                 self._quantum_kernel.set_params(**param_dict)

--- a/src/squlearn/kernel/ml/qkrr.py
+++ b/src/squlearn/kernel/ml/qkrr.py
@@ -78,7 +78,6 @@ class QKRR(BaseEstimator, RegressorMixin):
         self.k_testtrain = None
         self.k_train = None
         self.dual_coeff_ = None
-        # self.num_qubits = self._quantum_kernel.num_qubits
 
     def fit(self, x_train: np.ndarray, y_train: np.ndarray):
         """
@@ -134,18 +133,28 @@ class QKRR(BaseEstimator, RegressorMixin):
     def get_params(self, deep: bool = True):
         params = dict()
         params["quantum_kernel"] = self._quantum_kernel
+        params["alpha"] = self.alpha
         if deep:
             params.update(self._quantum_kernel.get_params(deep=True))
         else:
             params.update(self._quantum_kernel.get_params(deep=False))
-        params["alpha"] = self.alpha
         return params
 
     def set_params(self, **params):
-        valid_params = self.get_params(deep=True)
+        valid_params = self.get_params()
         param_dict = {}
         for key, value in params.items():
-            if key in valid_params:
+            #if key in valid_params:
+            if key in self._quantum_kernel.get_params().keys():
                 param_dict[key] = value
-                self._quantum_kernel.set_params(**param_dict)
+        self._quantum_kernel.set_params(**param_dict)
+
+        if "alpha" in params.keys():
+            self.alpha = params["alpha"]
+
+        self.__init__(
+            self._quantum_kernel,
+            self.alpha
+        )
+        
         return self

--- a/src/squlearn/kernel/ml/qkrr.py
+++ b/src/squlearn/kernel/ml/qkrr.py
@@ -71,7 +71,7 @@ class QKRR(BaseEstimator, RegressorMixin):
         self,
         quantum_kernel: Optional[KernelMatrixBase] = None,
         alpha: Union[float, np.ndarray] = 1.0e-6,
-        **kwargs
+        **kwargs,
     ) -> None:
         self._quantum_kernel = quantum_kernel
         self.alpha = alpha

--- a/src/squlearn/kernel/ml/qkrr.py
+++ b/src/squlearn/kernel/ml/qkrr.py
@@ -71,6 +71,7 @@ class QKRR(BaseEstimator, RegressorMixin):
         self,
         quantum_kernel: Optional[KernelMatrixBase] = None,
         alpha: Union[float, np.ndarray] = 1.0e-6,
+        **kwargs
     ) -> None:
         self._quantum_kernel = quantum_kernel
         self.alpha = alpha
@@ -78,6 +79,15 @@ class QKRR(BaseEstimator, RegressorMixin):
         self.k_testtrain = None
         self.k_train = None
         self.dual_coeff_ = None
+
+        # Apply kwargs to quantum kernel set_params
+        valid_params = self.get_params().keys()
+        set_params_dict = {}
+        for key, value in kwargs.items():
+            if key in valid_params:
+                set_params_dict[key] = value
+        if len(set_params_dict) > 0:
+            self.set_params(**set_params_dict)
 
     def fit(self, x_train: np.ndarray, y_train: np.ndarray):
         """


### PR DESCRIPTION
* Can't set "gamma" parameter when using "gaussian" outer_kernel in PQK => didn't manage to fix this
* Modified FQK such that evaluate_duplicates and mit_depol_noise is also returned from get_params(deep=True) -> not sure if we really want this?
* Do we want to include the regularization parameter into getters and setters?