### PR TITLE
Add Legal Notices

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,3 +17,4 @@ Welcome to sQUlearn's documentation!
    user_guide/user_guide_index
    modules/classes
    examples/examples_index
+   legal/legal_index

--- a/docs/legal/legal_index.rst
+++ b/docs/legal/legal_index.rst
@@ -1,0 +1,12 @@
+.. _legal:
+
+Legal Notices
+=============
+
+The following Editorial Notes (Impressum) and Data Protection Information (Datenschutzinformation) are required by German law.
+
+.. toctree::
+   :maxdepth: 1
+
+   Editorial Notes <https://dsi.informationssicherheit.fraunhofer.de/en/impressum/squlearn.github.io/full>
+   data_protection <https://dsi.informationssicherheit.fraunhofer.de/en/dsi/squlearn.github.io/full>

--- a/docs/legal/legal_index.rst
+++ b/docs/legal/legal_index.rst
@@ -9,4 +9,4 @@ The following Editorial Notes (Impressum) and Data Protection Information (Daten
    :maxdepth: 1
 
    Editorial Notes <https://dsi.informationssicherheit.fraunhofer.de/en/impressum/squlearn.github.io/full>
-   data_protection <https://dsi.informationssicherheit.fraunhofer.de/en/dsi/squlearn.github.io/full>
+   Data Protection <https://dsi.informationssicherheit.fraunhofer.de/en/dsi/squlearn.github.io/full>

--- a/docs/legal/legal_index.rst
+++ b/docs/legal/legal_index.rst
@@ -9,4 +9,4 @@ The following Editorial Notes (Impressum) and Data Protection Information (Daten
    :maxdepth: 1
 
    Editorial Notes <https://dsi.informationssicherheit.fraunhofer.de/en/impressum/squlearn.github.io/full>
-   Data Protection <https://dsi.informationssicherheit.fraunhofer.de/en/dsi/squlearn.github.io/full>
+   Data Protection Information <https://dsi.informationssicherheit.fraunhofer.de/en/dsi/squlearn.github.io/full>

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -7,12 +7,14 @@ Chebyshev
 Cholesky
 CNOT
 cov
+Datenschutzinformation
 Hadamard
 Hamiltonian
 Hamiltonians
 Hubregtsen
 hyperparameter
 hyperparameters
+Impressum
 Ising
 Laplacian
 Matern


### PR DESCRIPTION
This PR adds a section in the toctree directly forwarding to the editorial notes and data protection information generated with the dsi-generator. The pages are adapted to adopt our design when the documentation is launched.