### PR TITLE
Re-add measurement go get_params of PQKs

### DIFF
--- a/src/squlearn/kernel/matrix/projected_quantum_kernel.py
+++ b/src/squlearn/kernel/matrix/projected_quantum_kernel.py
@@ -473,6 +473,7 @@ class ProjectedQuantumKernel(KernelMatrixBase):
         """
         params = super().get_params(deep=False)
         params.update(self._outer_kernel.get_params())
+        params["measurement"] = self._measurement_input
         params["num_qubits"] = self.num_qubits
         params["regularization"] = self._regularization
         if deep:


### PR DESCRIPTION
This has been accidentally removed in one of the last PRs during our journey to sklearn compatibility. Now the QSM tests should work again