### PR TITLE
fix example digit classification

### DIFF
--- a/docs/examples/example_kernel_digit_classification.nblink
+++ b/docs/examples/example_kernel_digit_classification.nblink
@@ -1,0 +1,6 @@
+{
+    "path": "../../examples/tutorials/kernel_digit_classification.ipynb",
+    "extra-media": [
+        "../../examples/tutorials/images"
+    ]
+}

--- a/docs/examples/example_kernel_mnist.nblink
+++ b/docs/examples/example_kernel_mnist.nblink
@@ -1,6 +1,0 @@
-{
-    "path": "../../examples/tutorials/kernel_classification_mnist.ipynb",
-    "extra-media": [
-        "../../examples/tutorials/images"
-    ]
-}

--- a/docs/examples/examples_index.rst
+++ b/docs/examples/examples_index.rst
@@ -7,5 +7,5 @@ Examples
     :maxdepth: 3
     :glob:
 
-    example_kernel_mnist
+    example_kernel_digit_classification
     example_kernel_grid_search

--- a/examples/tutorials/kernel_digit_classification.ipynb
+++ b/examples/tutorials/kernel_digit_classification.ipynb
@@ -242,7 +242,7 @@
    "metadata": {},
    "source": [
     "## The Data\n",
-    "The MNIST data set is a well known example of a classification task. The data set is comprised of pictures of the size $28 \\times 28$ pixels that contain one single digit each as well as their according label, the numeric digit, depicted. We start by loading the data set from files and display the data."
+    "Classification of handwritten digits is a widely known task in machine learning. We utilize the data set included in scikit-learn. The data set is comprised of pictures of the size $8 \\times 8$ pixels that contain one single digit each as well as their according label, the numeric digit, depicted. We start by loading the data set and display the data."
    ]
   },
   {

--- a/examples/tutorials/kernel_grid_search.ipynb
+++ b/examples/tutorials/kernel_grid_search.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Hyperparamter Optimization and Pipelines\n",
+    "## Hyperparameter Optimization and Pipelines\n",
     "\n",
     "### Summary\n",
     "\n",
@@ -109,7 +109,7 @@
    "source": [
     "### Setting up the kernels\n",
     "\n",
-    "We want to compare two QML algorithms with the same feature map and two variants of calculating the kernel: Fidelity kernels and projected quantum kernels. We set up the feature map with inital parameters. These will be varied during the grid search. The kernel instances are initialzed using a statevector simulator."
+    "We want to compare two QML algorithms with the same feature map and two variants of calculating the kernel: Fidelity kernels and projected quantum kernels. We set up the feature map with initial parameters. These will be varied during the grid search. The kernel instances are initialized using Qiskit's StatevectorSimulator."
    ]
   },
   {
@@ -285,7 +285,7 @@
    "source": [
     "### Results Analysis\n",
     "\n",
-    "To visualize the performance of different hyperparameter combinations, we plot heatmaps for each estimator. Each cell in the heatmap represents a combination of the number of qubits and layers used in the quantum feature map, and the color represents the negative mean test score (MSE, larger is better). This allows for an intuitive understanding of how different hyperparameters impact performance."
+    "To visualize the performance of different hyperparameter combinations, we plot heat maps for each estimator. Each cell in the heat map represents a combination of the number of qubits and layers used in the quantum feature map, and the color represents the negative mean test score (MSE, larger is better). This allows for an intuitive understanding of how different hyperparameters impact performance."
    ]
   },
   {
@@ -339,22 +339,22 @@
     "vmax = results_df[\"mean_test_score\"].max()\n",
     "\n",
     "estimator_names = [\"QGPR Fidelity\", \"QGPR PQK\", \"QSVR Fidelity\", \"QSVR Fidelity\"]\n",
-    "# Loop through the chunks to plot each heatmap\n",
+    "# Loop through the chunks to plot each heat map\n",
     "for i in range(num_estimators):\n",
     "    start_idx = i * num_combinations\n",
     "    end_idx = (i + 1) * num_combinations\n",
     "    chunk_df = results_df.iloc[start_idx:end_idx]\n",
     "\n",
-    "    # Pivot to get a matrix form suitable for heatmaps\n",
-    "    heatmap_data = chunk_df.pivot_table(\n",
+    "    # Pivot to get a matrix form suitable for heat maps\n",
+    "    heat_map_data = chunk_df.pivot_table(\n",
     "        index=\"param_estimator__num_qubits\",\n",
     "        columns=\"param_estimator__num_layers\",\n",
     "        values=\"mean_test_score\",\n",
     "    )\n",
     "\n",
-    "    # Create the heatmap (cbar=False will disable individual colorbars)\n",
+    "    # Create the heat map (cbar=False will disable individual colorbars)\n",
     "    sns.heatmap(\n",
-    "        heatmap_data,\n",
+    "        heat_map_data,\n",
     "        annot=True,\n",
     "        fmt=\".3f\",\n",
     "        cmap=\"coolwarm\",\n",
@@ -434,7 +434,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that in the above evaluation, the QSVR did not perform quite as good as the QGPR. The QSVR is, as its classical counterpart, sensitive to additional hyperparamters which have not been varied during the grid search. We now include the classical regularization parameter C and the slack variable epsilon as additional parameters in the search. This also demonstrates that parameters of the quantum kernel and parameters of the classical algorithm can be treated equally during the search."
+    "Note that in the above evaluation, the QSVR did not perform quite as good as the QGPR. The QSVR is, as its classical counterpart, sensitive to additional hyperparameters which have not been varied during the grid search. We now include the classical regularization parameter C and the slack variable epsilon as additional parameters in the search. This also demonstrates that parameters of the quantum kernel and parameters of the classical algorithm can be treated equally during the search."
    ]
   },
   {

--- a/src/squlearn/kernel/ml/qgpc.py
+++ b/src/squlearn/kernel/ml/qgpc.py
@@ -107,7 +107,7 @@ class QGPC(GaussianProcessClassifier):
         Sets value of the QGPC hyper-parameters.
 
         Args:
-            params: Hyper-parameters and their values, e.g. num_qubits=2.
+            params: Hyper-parameters and their values, e.g. ``num_qubits=2``.
         """
         valid_params = self.get_params(deep=True)
         valid_params_qgpc = self.get_params(deep=False)

--- a/src/squlearn/kernel/ml/qgpr.py
+++ b/src/squlearn/kernel/ml/qgpr.py
@@ -223,7 +223,7 @@ class QGPR(BaseEstimator, RegressorMixin):
         Sets value of the feature map hyper-parameters.
 
         Args:
-            params: Hyper-parameters and their values, e.g. num_qubits=2.
+            params: Hyper-parameters and their values, e.g. ``num_qubits=2``.
         """
         valid_params = self.get_params()
         valid_params_qgpr = self.get_params(deep=False)


### PR DESCRIPTION
This PR:
- fixes some errors in the `example_digit_classification.ipynb`
- fixes some spelling errors