### PR TITLE
Clean `__init__` and  `set_params`

### DIFF
--- a/src/squlearn/kernel/ml/qgpc.py
+++ b/src/squlearn/kernel/ml/qgpc.py
@@ -60,19 +60,16 @@ class QGPC(GaussianProcessClassifier):
 
     def __init__(self, quantum_kernel: KernelMatrixBase, **kwargs) -> None:
         self._quantum_kernel = quantum_kernel
+
         # Apply kwargs to set_params of quantum kernel
-        valid_params_quantum_kernel = self._quantum_kernel.get_params(deep=True)
-        set_quantum_kernel_params_dict = {}
-        for key, value in kwargs.items():
-            if key in valid_params_quantum_kernel:
-                set_quantum_kernel_params_dict[key] = value
-
-        if len(set_quantum_kernel_params_dict) > 0:
-            self._quantum_kernel.set_params(**set_quantum_kernel_params_dict)
-
-        # remove quantum_kernel_kwargs for QGPC initialization
-        for key in set_quantum_kernel_params_dict:
-            kwargs.pop(key, None)
+        quantum_kernel_update_params = self.quantum_kernel.get_params().keys() & kwargs.keys()
+        if quantum_kernel_update_params:
+            self.quantum_kernel.set_params(
+                **{key: kwargs[key] for key in quantum_kernel_update_params}
+            )
+            # remove quantum_kernel_kwargs for SVR initialization
+            for key in quantum_kernel_update_params:
+                kwargs.pop(key, None)
 
         super().__init__(**kwargs)
         self.kernel = kernel_wrapper(self._quantum_kernel)
@@ -114,30 +111,25 @@ class QGPC(GaussianProcessClassifier):
         Args:
             params: Hyper-parameters and their values, e.g. ``num_qubits=2``.
         """
-        valid_params = self.get_params(deep=True)
-        valid_params_qgpc = self.get_params(deep=False)
-        valid_params_quantum_kernel = self._quantum_kernel.get_params(deep=True)
-        for key, value in params.items():
+        valid_params = self.get_params(deep=True).keys()
+        for key in params.keys():
             if key not in valid_params:
                 raise ValueError(
                     f"Invalid parameter {key!r}. "
                     f"Valid parameters are {sorted(valid_params)!r}."
                 )
-
-            # Set parameters of the QGPC
-            if key in valid_params_qgpc:
-                try:
-                    setattr(self, key, value)
-                except:
-                    setattr(self, "_" + key, value)
+        
+        self_params = self.get_params(deep=False).keys() & params.keys()
+        for  key in self_params:
+            try:
+                setattr(self, key, params[key])
+            except AttributeError:
+                setattr(self, "_" + key, params[key])
 
         # Set parameters of the Quantum Kernel and its underlying objects
-        param_dict = {}
-        for key, value in params.items():
-            if key in valid_params_quantum_kernel:
-                param_dict[key] = value
-        if len(param_dict) > 0:
-            self._quantum_kernel.set_params(**param_dict)
+        quantum_kernel_params = self._quantum_kernel.get_params().keys() & params.keys()
+        if quantum_kernel_params:
+            self._quantum_kernel.set_params(**{key: params[key] for key in quantum_kernel_params})
         return self
 
     @property

--- a/src/squlearn/kernel/ml/qgpc.py
+++ b/src/squlearn/kernel/ml/qgpc.py
@@ -118,9 +118,9 @@ class QGPC(GaussianProcessClassifier):
                     f"Invalid parameter {key!r}. "
                     f"Valid parameters are {sorted(valid_params)!r}."
                 )
-        
+
         self_params = self.get_params(deep=False).keys() & params.keys()
-        for  key in self_params:
+        for key in self_params:
             try:
                 setattr(self, key, params[key])
             except AttributeError:

--- a/src/squlearn/kernel/ml/qkrr.py
+++ b/src/squlearn/kernel/ml/qkrr.py
@@ -176,27 +176,23 @@ class QKRR(BaseEstimator, RegressorMixin):
             params: Hyperparameters and their values, e.g. ``num_qubits=2``.
         """
         valid_params = self.get_params()
-        valid_params_qkrr = self.get_params(deep=False)
-        for key, value in params.items():
+        for key in params.keys():
             if key not in valid_params:
                 raise ValueError(
                     f"Invalid parameter {key!r}. "
                     f"Valid parameters are {sorted(valid_params)!r}."
                 )
 
-            # Set parameters of the QKRR
-            if key in valid_params_qkrr:
-                try:
-                    setattr(self, key, value)
-                except:
-                    setattr(self, "_" + key, value)
+        # Set parameters of the QKRR
+        self_params = self.get_params(deep=False).keys() & params.keys()
+        for key in self_params:
+            try:
+                setattr(self, key, params[key])
+            except AttributeError:
+                setattr(self, "_" + key, params[key])
 
         # Set parameters of the Quantum Kernel and its underlying objects
-        param_dict = {}
-        valid_params = self._quantum_kernel.get_params().keys()
-        for key, value in params.items():
-            if key in valid_params:
-                param_dict[key] = value
-        if len(param_dict) > 0:
-            self._quantum_kernel.set_params(**param_dict)
+        quantum_kernel_params = self._quantum_kernel.get_params().keys() & params.keys()
+        if quantum_kernel_params:
+            self._quantum_kernel.set_params(**{key: params[key] for key in quantum_kernel_params})
         return self

--- a/src/squlearn/kernel/ml/qsvc.py
+++ b/src/squlearn/kernel/ml/qsvc.py
@@ -134,9 +134,9 @@ class QSVC(SVC):
                     f"Invalid parameter {key!r}. "
                     f"Valid parameters are {sorted(valid_params)!r}."
                 )
-        
+
         self_params = self.get_params(deep=False).keys() & params.keys()
-        for  key in self_params:
+        for key in self_params:
             try:
                 setattr(self, key, params[key])
             except AttributeError:

--- a/src/squlearn/kernel/ml/qsvc.py
+++ b/src/squlearn/kernel/ml/qsvc.py
@@ -74,18 +74,14 @@ class QSVC(SVC):
         self.quantum_kernel = quantum_kernel
 
         # Apply kwargs to set_params of quantum kernel
-        valid_params_quantum_kernel = self.quantum_kernel.get_params(deep=True)
-        set_quantum_kernel_params_dict = {}
-        for key, value in kwargs.items():
-            if key in valid_params_quantum_kernel:
-                set_quantum_kernel_params_dict[key] = value
-
-        if len(set_quantum_kernel_params_dict) > 0:
-            self.quantum_kernel.set_params(**set_quantum_kernel_params_dict)
-
-        # remove quantum_kernel_kwargs for SVC initialization
-        for key in set_quantum_kernel_params_dict:
-            kwargs.pop(key, None)
+        quantum_kernel_update_params = self.quantum_kernel.get_params().keys() & kwargs.keys()
+        if quantum_kernel_update_params:
+            self.quantum_kernel.set_params(
+                **{key: kwargs[key] for key in quantum_kernel_update_params}
+            )
+            # remove quantum_kernel_kwargs for SVR initialization
+            for key in quantum_kernel_update_params:
+                kwargs.pop(key, None)
 
         super().__init__(
             kernel=self.quantum_kernel.evaluate,
@@ -131,28 +127,23 @@ class QSVC(SVC):
         Args:
             params: Hyper-parameters and their values, e.g. ``num_qubits=2``.
         """
-        valid_params = self.get_params(deep=True)
-        valid_params_qsvc = self.get_params(deep=False)
-        valid_params_quantum_kernel = self.quantum_kernel.get_params(deep=True)
-        for key, value in params.items():
+        valid_params = self.get_params(deep=True).keys()
+        for key in params.keys():
             if key not in valid_params:
                 raise ValueError(
                     f"Invalid parameter {key!r}. "
                     f"Valid parameters are {sorted(valid_params)!r}."
                 )
-
-            # Set parameters of the QSVC
-            if key in valid_params_qsvc:
-                try:
-                    setattr(self, key, value)
-                except:
-                    setattr(self, "_" + key, value)
+        
+        self_params = self.get_params(deep=False).keys() & params.keys()
+        for  key in self_params:
+            try:
+                setattr(self, key, params[key])
+            except AttributeError:
+                setattr(self, "_" + key, params[key])
 
         # Set parameters of the Quantum Kernel and its underlying objects
-        param_dict = {}
-        for key, value in params.items():
-            if key in valid_params_quantum_kernel:
-                param_dict[key] = value
-        if len(param_dict) > 0:
-            self.quantum_kernel.set_params(**param_dict)
+        quantum_kernel_params = self.quantum_kernel.get_params().keys() & params.keys()
+        if quantum_kernel_params:
+            self.quantum_kernel.set_params(**{key: params[key] for key in quantum_kernel_params})
         return self

--- a/src/squlearn/kernel/ml/qsvr.py
+++ b/src/squlearn/kernel/ml/qsvr.py
@@ -133,9 +133,9 @@ class QSVR(SVR):
                     f"Invalid parameter {key!r}. "
                     f"Valid parameters are {sorted(valid_params)!r}."
                 )
-        
+
         self_params = self.get_params(deep=False).keys() & params.keys()
-        for  key in self_params:
+        for key in self_params:
             try:
                 setattr(self, key, params[key])
             except AttributeError:

--- a/src/squlearn/kernel/ml/qsvr.py
+++ b/src/squlearn/kernel/ml/qsvr.py
@@ -73,18 +73,14 @@ class QSVR(SVR):
         self.quantum_kernel = quantum_kernel
 
         # Apply kwargs to set_params of quantum kernel
-        valid_params_quantum_kernel = self.quantum_kernel.get_params(deep=True)
-        set_quantum_kernel_params_dict = {}
-        for key, value in kwargs.items():
-            if key in valid_params_quantum_kernel:
-                set_quantum_kernel_params_dict[key] = value
-
-        if len(set_quantum_kernel_params_dict) > 0:
-            self.quantum_kernel.set_params(**set_quantum_kernel_params_dict)
-
-        # remove quantum_kernel_kwargs for SVR initialization
-        for key in set_quantum_kernel_params_dict:
-            kwargs.pop(key, None)
+        quantum_kernel_update_params = self.quantum_kernel.get_params().keys() & kwargs.keys()
+        if quantum_kernel_update_params:
+            self.quantum_kernel.set_params(
+                **{key: kwargs[key] for key in quantum_kernel_update_params}
+            )
+            # remove quantum_kernel_kwargs for SVR initialization
+            for key in quantum_kernel_update_params:
+                kwargs.pop(key, None)
 
         super().__init__(
             kernel=self.quantum_kernel.evaluate,
@@ -130,28 +126,23 @@ class QSVR(SVR):
         Args:
             params: Hyper-parameters and their values, e.g. ``num_qubits=2``.
         """
-        valid_params = self.get_params(deep=True)
-        valid_params_qsvr = self.get_params(deep=False)
-        valid_params_quantum_kernel = self.quantum_kernel.get_params(deep=True)
-        for key, value in params.items():
+        valid_params = self.get_params(deep=True).keys()
+        for key in params.keys():
             if key not in valid_params:
                 raise ValueError(
                     f"Invalid parameter {key!r}. "
                     f"Valid parameters are {sorted(valid_params)!r}."
                 )
-
-            # Set parameters of the QSVR
-            if key in valid_params_qsvr:
-                try:
-                    setattr(self, key, value)
-                except:
-                    setattr(self, "_" + key, value)
+        
+        self_params = self.get_params(deep=False).keys() & params.keys()
+        for  key in self_params:
+            try:
+                setattr(self, key, params[key])
+            except AttributeError:
+                setattr(self, "_" + key, params[key])
 
         # Set parameters of the Quantum Kernel and its underlying objects
-        param_dict = {}
-        for key, value in params.items():
-            if key in valid_params_quantum_kernel:
-                param_dict[key] = value
-        if len(param_dict) > 0:
-            self.quantum_kernel.set_params(**param_dict)
+        quantum_kernel_params = self.quantum_kernel.get_params().keys() & params.keys()
+        if quantum_kernel_params:
+            self.quantum_kernel.set_params(**{key: params[key] for key in quantum_kernel_params})
         return self

--- a/src/squlearn/qnn/base_qnn.py
+++ b/src/squlearn/qnn/base_qnn.py
@@ -179,7 +179,7 @@ class BaseQNN(BaseEstimator, ABC):
         qnn_params = params.keys() & self._qnn.get_params(deep=True).keys()
         if qnn_params:
             self._qnn.set_params(
-                **{key: value for key, value in params.items() if key in qnn_params}
+                **{key: params[key] for key in qnn_params}
             )
 
             # If the number of parameters has changed, reinitialize the parameters

--- a/src/squlearn/qnn/base_qnn.py
+++ b/src/squlearn/qnn/base_qnn.py
@@ -178,9 +178,7 @@ class BaseQNN(BaseEstimator, ABC):
         # Set parameters of the QNN
         qnn_params = params.keys() & self._qnn.get_params(deep=True).keys()
         if qnn_params:
-            self._qnn.set_params(
-                **{key: params[key] for key in qnn_params}
-            )
+            self._qnn.set_params(**{key: params[key] for key in qnn_params})
 
             # If the number of parameters has changed, reinitialize the parameters
             if self.feature_map.num_parameters != len(self.param_ini):


### PR DESCRIPTION
This PR
- utilizes bit-wise comparison between `kwargs` and `self.get_params()` in `__init__` to decide which arguments should be forwarded to `set_params`
- utilizes bit-wise comparison between `params` and according params in `set_params` to decide which arguments get assinged to which attribute
- closes issue #108 

All in all this unifies the code and in my opinion makes it cleaner and more readable. Open to discuss.