### PR TITLE
add qiskit options to docs

### DIFF
--- a/.github/workflows/doc_checks.yml
+++ b/.github/workflows/doc_checks.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   doc_checks:
     runs-on: ubuntu-latest
+    env:
+      QISKIT_SETTINGS: ${{github.workspace}}/docs/qiskit_settings.conf
 
     steps:
         - name: Cancel Workflow Action

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -8,6 +8,8 @@ jobs:
     publish-pages:
       name: Publish to GH Pages
       runs-on: ubuntu-latest
+      env:
+        QISKIT_SETTINGS: ${{github.workspace}}/docs/qiskit_settings.conf
       steps:
           - name: Checkout Source Code
             uses: actions/checkout@v2

--- a/docs/qiskit_settings.conf
+++ b/docs/qiskit_settings.conf
@@ -1,0 +1,3 @@
+[default]
+circuit_drawer = mpl
+circuit_mpl_style = clifford


### PR DESCRIPTION
This PR adds qiskit options in the docs folder and sets the `QISKIT_SETTINGS` path in the respective actions. This supresses a warning thrown by Qiskit's drawer.