### PR TITLE
Add arctan to chebyshev encoding circuits

### DIFF
--- a/src/squlearn/encoding_circuit/circuit_library/chebyshev_pqc.py
+++ b/src/squlearn/encoding_circuit/circuit_library/chebyshev_pqc.py
@@ -197,8 +197,7 @@ class ChebyshevPQC(EncodingCircuitBase):
                 f"Unknown value for nonlinearity: {kwargs['nonlinearity']}."
                 " Possible values are 'arccos' and 'arctan'"
             )
-        super().set_params(**kwargs)
-        return self
+        return super().set_params(**kwargs)
 
     def get_circuit(
         self,

--- a/src/squlearn/encoding_circuit/circuit_library/chebyshev_pqc.py
+++ b/src/squlearn/encoding_circuit/circuit_library/chebyshev_pqc.py
@@ -219,13 +219,13 @@ class ChebyshevPQC(EncodingCircuitBase):
 
         if self.nonlinearity == "arccos":
 
-            def phi_map(a, x):
+            def mapping(a, x):
                 """Helper function for returning a*arccos(x)"""
                 return a * np.arccos(x)
 
         elif self.nonlinearity == "arctan":
 
-            def phi_map(a, x):
+            def mapping(a, x):
                 """Helper function for returning a*arctan(x)"""
                 return a * np.arctan(x)
 
@@ -251,7 +251,7 @@ class ChebyshevPQC(EncodingCircuitBase):
             # Chebyshev encoding circuit
             for i in range(self.num_qubits):
                 QC.rx(
-                    phi_map(
+                    mapping(
                         parameters[index_offset % nparam], features[feature_offset % nfeature]
                     ),
                     i,

--- a/src/squlearn/encoding_circuit/circuit_library/chebyshev_pqc.py
+++ b/src/squlearn/encoding_circuit/circuit_library/chebyshev_pqc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from typing import Union
 
@@ -158,11 +160,6 @@ class ChebyshevPQC(EncodingCircuitBase):
         elif self.nonlinearity == "arctan":
             bounds[:, 0] = -np.inf
             bounds[:, 1] = np.inf
-        else:
-            raise ValueError(
-                f"Unknown value for nonlinearity: {self.nonlinearity}."
-                " Possible values are 'arccos' and 'arctan'"
-            )
         return bounds
 
     def get_params(self, deep: bool = True) -> dict:
@@ -184,6 +181,24 @@ class ChebyshevPQC(EncodingCircuitBase):
         params["nonlinearity"] = self.nonlinearity
 
         return params
+
+    def set_params(self, **kwargs) -> ChebyshevPQC:
+        """
+        Sets value of the encoding circuit hyper-parameters.
+
+        Args:
+            params: Hyper-parameters and their values, e.g. ``num_qubits=2``.
+        """
+        if "nonlinearity" in kwargs and kwargs["nonlinearity"] not in (
+            "arccos",
+            "arctan",
+        ):
+            raise ValueError(
+                f"Unknown value for nonlinearity: {kwargs['nonlinearity']}."
+                " Possible values are 'arccos' and 'arctan'"
+            )
+        super().set_params(**kwargs)
+        return self
 
     def get_circuit(
         self,
@@ -214,12 +229,6 @@ class ChebyshevPQC(EncodingCircuitBase):
             def phi_map(a, x):
                 """Helper function for returning a*arctan(x)"""
                 return a * np.arctan(x)
-
-        else:
-            raise ValueError(
-                f"Unknown value for nonlinearity: {self.nonlinearity}."
-                " Possible values are 'arccos' and 'arctan'"
-            )
 
         nfeature = len(features)
         nparam = len(parameters)

--- a/src/squlearn/encoding_circuit/circuit_library/chebyshev_rx.py
+++ b/src/squlearn/encoding_circuit/circuit_library/chebyshev_rx.py
@@ -27,8 +27,8 @@ class ChebyshevRx(EncodingCircuitBase):
         closed (bool): If true, the last and the first qubit are entangled (default: false)
         alpha (float): Maximum value of the Chebyshev Tower initial parameters, i.e. parameters
                        that appear in the arccos encoding. (default: 4.0)
-        phi_map (str): Mapping function to use for the feature encoding. Either ``arccos``
-                       or ``arctan`` (default: ``arccos``)
+        nonlinearity (str): Mapping function to use for the feature encoding. Either ``arccos``
+                            or ``arctan`` (default: ``arccos``)
     """
 
     def __init__(
@@ -38,15 +38,18 @@ class ChebyshevRx(EncodingCircuitBase):
         num_layers: int = 1,
         closed: bool = False,
         alpha: float = 4.0,
-        phi_map: str = "arccos",
+        nonlinearity: str = "arccos",
     ) -> None:
         super().__init__(num_qubits, num_features)
         self.num_layers = num_layers
         self.closed = closed
         self.alpha = alpha
-        self.phi_map = phi_map
-        if self.phi_map not in ("arccos", "arctan"):
-            raise ValueError("Unknown value for phi_map: ", phi_map)
+        self.nonlinearity = nonlinearity
+        if self.nonlinearity not in ("arccos", "arctan"):
+            raise ValueError(
+                f"Unknown value for nonlinearity: {self.nonlinearity}."
+                " Possible values are 'arccos' and 'arctan'"
+            )
 
     @property
     def num_parameters(self) -> int:
@@ -96,14 +99,17 @@ class ChebyshevRx(EncodingCircuitBase):
     def feature_bounds(self) -> np.ndarray:
         """The bounds of the features of the ChebyshevPQC encoding circuit."""
         bounds = np.zeros((self.num_features, 2))
-        if self.phi_map == "arccos":
+        if self.nonlinearity == "arccos":
             bounds[:, 0] = -1.0
             bounds[:, 1] = 1.0
-        elif self.phi_map == "arctan":
+        elif self.nonlinearity == "arctan":
             bounds[:, 0] = -np.inf
             bounds[:, 1] = np.inf
         else:
-            raise ValueError("Unknown value for phi_map: ", self.phi_map)
+            raise ValueError(
+                f"Unknown value for nonlinearity: {self.nonlinearity}."
+                " Possible values are 'arccos' and 'arctan'"
+            )
         return bounds
 
     def get_params(self, deep: bool = True) -> dict:
@@ -121,7 +127,7 @@ class ChebyshevRx(EncodingCircuitBase):
         params["num_layers"] = self.num_layers
         params["closed"] = self.closed
         params["alpha"] = self.alpha
-        params["phi_map"] = self.phi_map
+        params["nonlinearity"] = self.nonlinearity
         return params
 
     def get_circuit(
@@ -153,20 +159,23 @@ class ChebyshevRx(EncodingCircuitBase):
 
             return QC
 
-        if self.phi_map == "arccos":
+        if self.nonlinearity == "arccos":
 
             def mapping(a, x):
                 """Helper function for returning a*arccos(x)"""
                 return a * np.arccos(x)
 
-        elif self.phi_map == "arctan":
+        elif self.nonlinearity == "arctan":
 
             def mapping(a, x):
                 """Helper function for returning a*arctan(x)"""
                 return a * np.arctan(x)
 
         else:
-            raise ValueError("Unknown value for phi_map: ", self.phi_map)
+            raise ValueError(
+                f"Unknown value for nonlinearity: {self.nonlinearity}."
+                " Possible values are 'arccos' and 'arctan'"
+            )
 
         nfeature = len(features)
         nparam = len(parameters)

--- a/src/squlearn/encoding_circuit/circuit_library/chebyshev_rx.py
+++ b/src/squlearn/encoding_circuit/circuit_library/chebyshev_rx.py
@@ -142,8 +142,7 @@ class ChebyshevRx(EncodingCircuitBase):
                 f"Unknown value for nonlinearity: {kwargs['nonlinearity']}."
                 " Possible values are 'arccos' and 'arctan'"
             )
-        super().set_params(**kwargs)
-        return self
+        return super().set_params(**kwargs)
 
     def get_circuit(
         self,

--- a/src/squlearn/encoding_circuit/circuit_library/chebyshev_rx.py
+++ b/src/squlearn/encoding_circuit/circuit_library/chebyshev_rx.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from typing import Union
 
@@ -105,11 +107,6 @@ class ChebyshevRx(EncodingCircuitBase):
         elif self.nonlinearity == "arctan":
             bounds[:, 0] = -np.inf
             bounds[:, 1] = np.inf
-        else:
-            raise ValueError(
-                f"Unknown value for nonlinearity: {self.nonlinearity}."
-                " Possible values are 'arccos' and 'arctan'"
-            )
         return bounds
 
     def get_params(self, deep: bool = True) -> dict:
@@ -129,6 +126,24 @@ class ChebyshevRx(EncodingCircuitBase):
         params["alpha"] = self.alpha
         params["nonlinearity"] = self.nonlinearity
         return params
+
+    def set_params(self, **kwargs) -> ChebyshevRx:
+        """
+        Sets value of the encoding circuit hyper-parameters.
+
+        Args:
+            params: Hyper-parameters and their values, e.g. ``num_qubits=2``.
+        """
+        if "nonlinearity" in kwargs and kwargs["nonlinearity"] not in (
+            "arccos",
+            "arctan",
+        ):
+            raise ValueError(
+                f"Unknown value for nonlinearity: {kwargs['nonlinearity']}."
+                " Possible values are 'arccos' and 'arctan'"
+            )
+        super().set_params(**kwargs)
+        return self
 
     def get_circuit(
         self,
@@ -170,12 +185,6 @@ class ChebyshevRx(EncodingCircuitBase):
             def mapping(a, x):
                 """Helper function for returning a*arctan(x)"""
                 return a * np.arctan(x)
-
-        else:
-            raise ValueError(
-                f"Unknown value for nonlinearity: {self.nonlinearity}."
-                " Possible values are 'arccos' and 'arctan'"
-            )
 
         nfeature = len(features)
         nparam = len(parameters)

--- a/src/squlearn/encoding_circuit/circuit_library/chebyshev_tower.py
+++ b/src/squlearn/encoding_circuit/circuit_library/chebyshev_tower.py
@@ -129,8 +129,7 @@ class ChebyshevTower(EncodingCircuitBase):
                 f"Unknown value for nonlinearity: {kwargs['nonlinearity']}."
                 " Possible values are 'arccos' and 'arctan'"
             )
-        super().set_params(**kwargs)
-        return self
+        return super().set_params(**kwargs)
 
     def get_circuit(
         self,

--- a/src/squlearn/encoding_circuit/circuit_library/chebyshev_tower.py
+++ b/src/squlearn/encoding_circuit/circuit_library/chebyshev_tower.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from typing import Union
 
@@ -89,11 +91,6 @@ class ChebyshevTower(EncodingCircuitBase):
         elif self.nonlinearity == "arctan":
             bounds[:, 0] = -np.inf
             bounds[:, 1] = np.inf
-        else:
-            raise ValueError(
-                f"Unknown value for nonlinearity: {self.nonlinearity}."
-                " Possible values are 'arccos' and 'arctan'"
-            )
         return bounds
 
     def get_params(self, deep: bool = True) -> dict:
@@ -116,6 +113,24 @@ class ChebyshevTower(EncodingCircuitBase):
         params["arrangement"] = self.arrangement
         params["nonlinearity"] = self.nonlinearity
         return params
+
+    def set_params(self, **kwargs) -> ChebyshevTower:
+        """
+        Sets value of the encoding circuit hyper-parameters.
+
+        Args:
+            params: Hyper-parameters and their values, e.g. ``num_qubits=2``.
+        """
+        if "nonlinearity" in kwargs and kwargs["nonlinearity"] not in (
+            "arccos",
+            "arctan",
+        ):
+            raise ValueError(
+                f"Unknown value for nonlinearity: {kwargs['nonlinearity']}."
+                " Possible values are 'arccos' and 'arctan'"
+            )
+        super().set_params(**kwargs)
+        return self
 
     def get_circuit(
         self,
@@ -160,12 +175,6 @@ class ChebyshevTower(EncodingCircuitBase):
             def mapping(x, i):
                 """Non-linear mapping for x: alpha*i*arctan(x)"""
                 return self.alpha * i * np.arctan(x)
-
-        else:
-            raise ValueError(
-                f"Unknown value for nonlinearity: {self.nonlinearity}."
-                " Possible values are 'arccos' and 'arctan'"
-            )
 
         nfeature = len(features)
 

--- a/src/squlearn/encoding_circuit/circuit_library/chebyshev_tower.py
+++ b/src/squlearn/encoding_circuit/circuit_library/chebyshev_tower.py
@@ -36,8 +36,8 @@ class ChebyshevTower(EncodingCircuitBase):
         arrangement (str): Arrangement of the layers, either ``block`` or ``alternating``.
                           ``block``: The features are stacked together, ``alternating``:
                           The features are placed alternately (default: ``block``).
-        phi_map (str): Mapping function to use for the feature encoding. Either ``arccos``
-                       or ``arctan`` (default: ``arccos``)
+        nonlinearity (str): Mapping function to use for the feature encoding. Either ``arccos``
+                            or ``arctan`` (default: ``arccos``)
     """
 
     def __init__(
@@ -50,7 +50,7 @@ class ChebyshevTower(EncodingCircuitBase):
         rotation_gate: str = "ry",
         hadamard_start: bool = True,
         arrangement: str = "block",
-        phi_map: str = "arccos",
+        nonlinearity: str = "arccos",
     ) -> None:
         super().__init__(num_qubits, num_features)
 
@@ -60,7 +60,7 @@ class ChebyshevTower(EncodingCircuitBase):
         self.rotation_gate = rotation_gate
         self.hadamard_start = hadamard_start
         self.arrangement = arrangement
-        self.phi_map = phi_map
+        self.nonlinearity = nonlinearity
 
         if self.rotation_gate not in ("rx", "ry", "rz"):
             raise ValueError("Rotation gate must be either 'rx', 'ry' or 'rz'")
@@ -68,8 +68,11 @@ class ChebyshevTower(EncodingCircuitBase):
         if self.arrangement not in ("block", "alternating"):
             raise ValueError("Arrangement must be either 'block' or 'alternating'")
 
-        if self.phi_map not in ("arccos", "arctan"):
-            raise ValueError("Unknown value for phi_map: ", phi_map)
+        if self.nonlinearity not in ("arccos", "arctan"):
+            raise ValueError(
+                f"Unknown value for nonlinearity: {self.nonlinearity}."
+                " Possible values are 'arccos' and 'arctan'"
+            )
 
     @property
     def num_parameters(self) -> int:
@@ -80,14 +83,17 @@ class ChebyshevTower(EncodingCircuitBase):
     def feature_bounds(self) -> np.ndarray:
         """The bounds of the features of the ChebyshevPQC encoding circuit."""
         bounds = np.zeros((self.num_features, 2))
-        if self.phi_map == "arccos":
+        if self.nonlinearity == "arccos":
             bounds[:, 0] = -1.0
             bounds[:, 1] = 1.0
-        elif self.phi_map == "arctan":
+        elif self.nonlinearity == "arctan":
             bounds[:, 0] = -np.inf
             bounds[:, 1] = np.inf
         else:
-            raise ValueError("Unknown value for phi_map: ", self.phi_map)
+            raise ValueError(
+                f"Unknown value for nonlinearity: {self.nonlinearity}."
+                " Possible values are 'arccos' and 'arctan'"
+            )
         return bounds
 
     def get_params(self, deep: bool = True) -> dict:
@@ -108,7 +114,7 @@ class ChebyshevTower(EncodingCircuitBase):
         params["rotation_gate"] = self.rotation_gate
         params["hadamard_start"] = self.hadamard_start
         params["arrangement"] = self.arrangement
-        params["phi_map"] = self.phi_map
+        params["nonlinearity"] = self.nonlinearity
         return params
 
     def get_circuit(
@@ -143,20 +149,23 @@ class ChebyshevTower(EncodingCircuitBase):
                 QC.cx(i, i + 1)
             return QC
 
-        if self.phi_map == "arccos":
+        if self.nonlinearity == "arccos":
 
             def mapping(x, i):
                 """Non-linear mapping for x: alpha*i*arccos(x)"""
                 return self.alpha * i * np.arccos(x)
 
-        elif self.phi_map == "arctan":
+        elif self.nonlinearity == "arctan":
 
             def mapping(x, i):
                 """Non-linear mapping for x: alpha*i*arctan(x)"""
                 return self.alpha * i * np.arctan(x)
 
         else:
-            raise ValueError("Unknown value for phi_map: ", self.phi_map)
+            raise ValueError(
+                f"Unknown value for nonlinearity: {self.nonlinearity}."
+                " Possible values are 'arccos' and 'arctan'"
+            )
 
         nfeature = len(features)
 

--- a/src/squlearn/encoding_circuit/encoding_circuit_base.py
+++ b/src/squlearn/encoding_circuit/encoding_circuit_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from typing import Union
 
@@ -131,7 +133,7 @@ class EncodingCircuitBase:
         param["num_features"] = self._num_features
         return param
 
-    def set_params(self, **params) -> None:
+    def set_params(self, **params) -> EncodingCircuitBase:
         """
         Sets value of the encoding circuit hyper-parameters.
 
@@ -150,7 +152,7 @@ class EncodingCircuitBase:
             except:
                 setattr(self, "_" + key, value)
 
-        return None
+        return self
 
     def __mul__(self, x):
         return self.__add__(x)


### PR DESCRIPTION
This PR adds the possibility to choose the non-linear feature encoding out of `arccos` and `arctan` in chebyshev encoding circuits.