### PR TITLE
adjust docstrings and type definitions for fit methods

### DIFF
--- a/src/squlearn/kernel/ml/qgpr.py
+++ b/src/squlearn/kernel/ml/qgpr.py
@@ -106,16 +106,18 @@ class QGPR(BaseEstimator, RegressorMixin):
         if update_params:
             self.set_params(**{key: kwargs[key] for key in update_params})
 
-    def fit(self, X: np.ndarray, y: np.ndarray):
+    def fit(self, X, y):
         """Fit Quantum Gaussian process regression model.
         The fit method of the QGPR class just calculates the training kernel matrix.
         Depending on the choice of normalize_y the target values are normalized.
 
         Args:
-            X: The training data of shape (n_samples, n_features). If
-                quantum_kernel == "precomputed" this is instead a precomputed training kernel
+            X: array-like or sparse matrix of shape (n_samples, n_features)
+                The training data.
+                If quantum_kernel == "precomputed" this is instead a precomputed training kernel
                 matrix of shape (n_samples, n_samples)
-            y: Target values of shape (n_samples,)
+            y: array-like of shape (n_samples,)
+                Target values.
 
         Returns:
             self: object

--- a/src/squlearn/kernel/ml/qkrr.py
+++ b/src/squlearn/kernel/ml/qkrr.py
@@ -103,7 +103,7 @@ class QKRR(BaseEstimator, RegressorMixin):
         if update_params:
             self.set_params(**{key: kwargs[key] for key in update_params})
 
-    def fit(self, X: np.ndarray, y: np.ndarray):
+    def fit(self, X, y):
         """
         Fit the Quantum Kernel Ridge regression model.
 
@@ -113,10 +113,11 @@ class QKRR(BaseEstimator, RegressorMixin):
         for providing numerical stability.
 
         Args:
-            X (np.ndarray) : Training data of shape (n_samples, n_features). If
-                quantum_kernel == "precomputed" this is instead a precomputed training kernel
+            X: array-like or sparse matrix of shape (n_samples, n_features)
+                If quantum_kernel == "precomputed" this is instead a precomputed training kernel
                 matrix of shape (n_samples, n_samples).
-            y (np.ndarray) : Target values or labels of shape (n_samples,)
+            y: array-like of shape (n_samples,)
+                Target values or labels
 
         Returns:
             self :

--- a/src/squlearn/qnn/base_qnn.py
+++ b/src/squlearn/qnn/base_qnn.py
@@ -311,8 +311,16 @@ class BaseQNN(BaseEstimator, ABC):
         return self
 
     @abstractmethod
-    def _fit(self, X: np.ndarray, y: np.ndarray, weights: np.ndarray = None) -> None:
-        """Internal fit function."""
+    def _fit(self, X, y, weights: np.ndarray = None) -> None:
+        """Internal fit function.
+
+        Args:
+            X: array-like or sparse matrix of shape (n_samples, n_features)
+                Input data
+            y: array-like or sparse matrix of shape (n_samples,)
+                Labels
+            weights: Weights for each data point
+        """
         raise NotImplementedError()
 
     def _initialize_lowlevel_qnn(self):

--- a/src/squlearn/qnn/base_qnn.py
+++ b/src/squlearn/qnn/base_qnn.py
@@ -182,14 +182,16 @@ class BaseQNN(BaseEstimator, ABC):
         """Number of parameters of the observable."""
         return self._qnn.num_parameters_observable
 
-    def fit(self, X: np.ndarray, y: np.ndarray, weights: np.ndarray = None) -> None:
+    def fit(self, X, y, weights: np.ndarray = None) -> None:
         """Fit a new model to data.
 
         This method will reinitialize the models parameters and fit it to the provided data.
 
         Args:
-            X: Input data
-            y: Labels
+            X: array-like or sparse matrix of shape (n_samples, n_features)
+                Input data
+            y: array-like of shape (n_samples,)
+                Labels
             weights: Weights for each data point
         """
         self._param = self.param_ini.copy()

--- a/src/squlearn/qnn/qnnc.py
+++ b/src/squlearn/qnn/qnnc.py
@@ -179,15 +179,17 @@ class QNNClassifier(BaseQNN, ClassifierMixin):
 
         return pred
 
-    def partial_fit(self, X: np.ndarray, y: np.ndarray, weights: np.ndarray = None) -> None:
+    def partial_fit(self, X, y, weights: np.ndarray = None) -> None:
         """Fit a model to data.
 
         This method will update the models parameters to fit the provided data.
         It won't reinitialize the models parameters.
 
         Args:
-            X: Input data
-            y: Labels
+            X: array-like or sparse matrix of shape (n_samples, n_features)
+                Input data
+            y: array-like of shape (n_samples,)
+                Labels
             weights: Weights for each data point
         """
         X, y = self._validate_input(X, y, incremental=False, reset=False)
@@ -272,7 +274,7 @@ class QNNClassifier(BaseQNN, ClassifierMixin):
                 )
         self._is_fitted = True
 
-    def _fit(self, X: np.ndarray, y: np.ndarray, weights: np.ndarray = None) -> None:
+    def _fit(self, X, y, weights: np.ndarray = None) -> None:
         """Internal fit function."""
         if self.callback == "pbar":
             self._pbar = tqdm(total=self._total_iterations, desc="fit", file=sys.stdout)

--- a/src/squlearn/qnn/qnnc.py
+++ b/src/squlearn/qnn/qnnc.py
@@ -275,7 +275,15 @@ class QNNClassifier(BaseQNN, ClassifierMixin):
         self._is_fitted = True
 
     def _fit(self, X, y, weights: np.ndarray = None) -> None:
-        """Internal fit function."""
+        """Internal fit function.
+
+        Args:
+            X: array-like or sparse matrix of shape (n_samples, n_features)
+                Input data
+            y: array-like or sparse matrix of shape (n_samples,)
+                Labels
+            weights: Weights for each data point
+        """
         if self.callback == "pbar":
             self._pbar = tqdm(total=self._total_iterations, desc="fit", file=sys.stdout)
         self.partial_fit(X, y, weights)

--- a/src/squlearn/qnn/qnnr.py
+++ b/src/squlearn/qnn/qnnr.py
@@ -156,15 +156,17 @@ class QNNRegressor(BaseQNN, RegressorMixin):
 
         return self._qnn.evaluate(X, self._param, self._param_op, "f")["f"]
 
-    def partial_fit(self, X: np.ndarray, y: np.ndarray, weights: np.ndarray = None) -> None:
+    def partial_fit(self, X, y, weights: np.ndarray = None) -> None:
         """Fit a model to data.
 
         This method will update the models parameters to fit the provided data.
         It won't reinitialize the models parameters.
 
         Args:
-            X: Input data
-            y: Labels
+            X: array-like or sparse matrix of shape (n_samples, n_features)
+                Input data
+            y: array-like or sparse matrix of shape (n_samples,)
+                Labels
             weights: Weights for each data point
         """
         X, y = self._validate_input(X, y, incremental=False, reset=False)
@@ -236,7 +238,7 @@ class QNNRegressor(BaseQNN, RegressorMixin):
                 )
         self._is_fitted = True
 
-    def _fit(self, X: np.ndarray, y: np.ndarray, weights: np.ndarray = None) -> None:
+    def _fit(self, X, y, weights: np.ndarray = None) -> None:
         """Internal fit function."""
         if self.callback == "pbar":
             self._pbar = tqdm(total=self._total_iterations, desc="fit", file=sys.stdout)

--- a/src/squlearn/qnn/qnnr.py
+++ b/src/squlearn/qnn/qnnr.py
@@ -239,7 +239,15 @@ class QNNRegressor(BaseQNN, RegressorMixin):
         self._is_fitted = True
 
     def _fit(self, X, y, weights: np.ndarray = None) -> None:
-        """Internal fit function."""
+        """Internal fit function.
+
+        Args:
+            X: array-like or sparse matrix of shape (n_samples, n_features)
+                Input data
+            y: array-like or sparse matrix of shape (n_samples,)
+                Labels
+            weights: Weights for each data point
+        """
         if self.callback == "pbar":
             self._pbar = tqdm(total=self._total_iterations, desc="fit", file=sys.stdout)
         self.partial_fit(X, y, weights)


### PR DESCRIPTION
To fit the doc style of sklearn:
- removed the type definitions (`np.ndarray`) for X and y in the fit methods of the HLMs
- added the same type hints for X and y as in sklearn:
     -  `X: array-like or sparse matrix of shape (n_samples, n_features)`
     - `y: array-like of shape (n_samples,)`