### PR TITLE
WIP: Qiskit 2 support

### DIFF
--- a/src/squlearn/util/execution/automatic_backend_selection.py
+++ b/src/squlearn/util/execution/automatic_backend_selection.py
@@ -11,9 +11,6 @@ from packaging import version
 from qiskit import qasm3, transpile, QuantumCircuit
 from qiskit import __version__ as qiskit_version
 from qiskit.providers import Backend, BackendV2
-from qiskit.providers.fake_provider.utils.json_decoder import (
-    decode_backend_properties,
-)
 from qiskit.providers.models import BackendProperties
 from qiskit_ibm_runtime import QiskitRuntimeService
 import mapomatic as mm

--- a/src/squlearn/util/executor.py
+++ b/src/squlearn/util/executor.py
@@ -22,10 +22,6 @@ from qiskit.circuit import QuantumCircuit
 from qiskit import __version__ as qiskit_version
 from qiskit.circuit import ParameterVector
 from qiskit.exceptions import QiskitError
-from qiskit.primitives import (
-    Estimator as PrimitiveEstimatorV1,
-    Sampler as PrimitiveSamplerV1,
-)
 from qiskit.primitives.base import EstimatorResult, SamplerResult
 from qiskit.providers import JobV1
 from qiskit.providers import Options
@@ -48,12 +44,11 @@ from qiskit_algorithms.utils import algorithm_globals as qiskit_algorithm_global
 
 QISKIT_SMALLER_1_0 = version.parse(qiskit_version) < version.parse("1.0.0")
 QISKIT_SMALLER_1_2 = version.parse(qiskit_version) < version.parse("1.2.0")
+QISKIT_SMALLER_2_0 = version.parse(qiskit_version) < version.parse("2.0.0")
 
 if QISKIT_SMALLER_1_0:
     # pylint: disable=ungrouped-imports
     from qiskit.primitives import (
-        BackendEstimator as BackendEstimatorV1,
-        BackendSampler as BackendSamplerV1,
         BaseEstimator as BaseEstimatorV1,
         BaseSampler as BaseSamplerV1,
     )
@@ -84,8 +79,6 @@ if QISKIT_SMALLER_1_0:
 
 else:
     from qiskit.primitives import (
-        BackendEstimator as BackendEstimatorV1,
-        BackendSampler as BackendSamplerV1,
         BaseEstimatorV1,
         BaseEstimatorV2,
         BaseSamplerV1,
@@ -113,6 +106,28 @@ else:
         BackendEstimatorV2,
         BackendSamplerV2,
     )
+
+if QISKIT_SMALLER_2_0:
+    # pylint: disable=ungrouped-imports
+    from qiskit.primitives import (
+        BackendEstimator as BackendEstimatorV1,
+        BackendSampler as BackendSamplerV1,
+        Estimator as PrimitiveEstimatorV1,
+        Sampler as PrimitiveSamplerV1,
+    )
+else:
+
+    class BackendEstimatorV1:
+        """Dummy BackendEstimatorV1"""
+
+    class BackendSamplerV1:
+        """Dummy BackendSamplerV1"""
+
+    class PrimitiveEstimatorV1:
+        """Dummy PrimitiveEstimatorV1"""
+
+    class PrimitiveSamplerV1:
+        """Dummy PrimitiveSamplerV1"""
 
 
 QISKIT_RUNTIME_SMALLER_0_21 = version.parse(ibm_runtime_version) < version.parse("0.21.0")


### PR DESCRIPTION
A couple of changes are necessary to support Qiskit 2.0. I started to adapt some things but there are still things missing, also some things wee need to wait on.

- [ ] `qiskit_algorithms` needs to be updated to support 2.0
- [ ] `BackendProperties` doesn't seem to exist anymore and needs to be replaced accordingly in `automatic_backend_selection`