### PR TITLE
model serialization

### DIFF
--- a/src/squlearn/kernel/qgpc.py
+++ b/src/squlearn/kernel/qgpc.py
@@ -2,11 +2,13 @@
 
 from sklearn.gaussian_process import GaussianProcessClassifier
 
+from squlearn.util.serialization.serializable_model_mixin import SerializableModelMixin
+
 from .lowlevel_kernel.kernel_matrix_base import KernelMatrixBase
 from .lowlevel_kernel.kernel_util import kernel_wrapper
 
 
-class QGPC(GaussianProcessClassifier):
+class QGPC(GaussianProcessClassifier, SerializableModelMixin):
     """
     Quantum Gaussian process classification (QGPC), that extends the scikit-learn
     `sklearn.gaussian_process.GaussianProcessClassifier

--- a/src/squlearn/kernel/qgpr.py
+++ b/src/squlearn/kernel/qgpr.py
@@ -11,6 +11,8 @@ from sklearn.preprocessing._data import _handle_zeros_in_scale
 
 from sklearn import __version__
 
+from squlearn.util.serialization.serializable_model_mixin import SerializableModelMixin
+
 if version.parse(__version__) >= version.parse("1.6"):
     from sklearn.utils.validation import validate_data
 else:
@@ -23,7 +25,7 @@ from .lowlevel_kernel.kernel_matrix_base import KernelMatrixBase
 from .lowlevel_kernel.regularization import regularize_full_kernel
 
 
-class QGPR(BaseEstimator, RegressorMixin):
+class QGPR(BaseEstimator, RegressorMixin, SerializableModelMixin):
     """
     Quantum Gaussian Process Regression (QGPR).
 

--- a/src/squlearn/kernel/qkrr.py
+++ b/src/squlearn/kernel/qkrr.py
@@ -8,6 +8,8 @@ from typing import Optional, Union
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn import __version__
 
+from squlearn.util.serialization.serializable_model_mixin import SerializableModelMixin
+
 if version.parse(__version__) >= version.parse("1.6"):
     from sklearn.utils.validation import validate_data
 else:
@@ -17,10 +19,9 @@ else:
 
 
 from .lowlevel_kernel.kernel_matrix_base import KernelMatrixBase
-from .lowlevel_kernel.regularization import thresholding_regularization, tikhonov_regularization
 
 
-class QKRR(BaseEstimator, RegressorMixin):
+class QKRR(BaseEstimator, RegressorMixin, SerializableModelMixin):
     r"""
     Quantum Kernel Ridge Regression.
 

--- a/src/squlearn/kernel/qsvc.py
+++ b/src/squlearn/kernel/qsvc.py
@@ -3,10 +3,12 @@
 from sklearn.svm import SVC
 from typing import Union, Optional
 
+from squlearn.util.serialization.serializable_model_mixin import SerializableModelMixin
+
 from .lowlevel_kernel.kernel_matrix_base import KernelMatrixBase
 
 
-class QSVC(SVC):
+class QSVC(SVC, SerializableModelMixin):
     """
     Quantum Support Vector Classification
 

--- a/src/squlearn/kernel/qsvr.py
+++ b/src/squlearn/kernel/qsvr.py
@@ -3,10 +3,12 @@
 from sklearn.svm import SVR
 from typing import Union, Optional
 
+from squlearn.util.serialization.serializable_model_mixin import SerializableModelMixin
+
 from .lowlevel_kernel.kernel_matrix_base import KernelMatrixBase
 
 
-class QSVR(SVR):
+class QSVR(SVR, SerializableModelMixin):
     """
     Quantum Support Vector Regression
 

--- a/src/squlearn/qnn/base_qnn.py
+++ b/src/squlearn/qnn/base_qnn.py
@@ -12,6 +12,8 @@ from sklearn.base import BaseEstimator
 from sklearn.utils import column_or_1d
 from sklearn import __version__
 
+from squlearn.util.serialization.serializable_model_mixin import SerializableModelMixin
+
 if version.parse(__version__) >= version.parse("1.6"):
     from sklearn.utils.validation import validate_data
 else:
@@ -31,7 +33,7 @@ from .lowlevel_qnn import LowLevelQNN
 from .util.training import ShotControlBase
 
 
-class BaseQNN(BaseEstimator, ABC):
+class BaseQNN(BaseEstimator, SerializableModelMixin, ABC):
     """Base Class for Quantum Neural Networks.
 
     Args:

--- a/src/squlearn/qrc/base_qrc.py
+++ b/src/squlearn/qrc/base_qrc.py
@@ -7,6 +7,8 @@ from sklearn.base import BaseEstimator
 from sklearn.utils import column_or_1d
 from sklearn import __version__
 
+from squlearn.util.serialization.serializable_model_mixin import SerializableModelMixin
+
 if version.parse(__version__) >= version.parse("1.6"):
     from sklearn.utils.validation import validate_data
 else:
@@ -25,7 +27,7 @@ from ..qnn.lowlevel_qnn.lowlevel_qnn_base import LowLevelQNNBase
 from ..qnn.lowlevel_qnn import LowLevelQNN
 
 
-class BaseQRC(BaseEstimator, ABC):
+class BaseQRC(BaseEstimator, SerializableModelMixin, ABC):
     """Base class for Quantum Reservoir Computing (QRC) models.
 
     Args:

--- a/src/squlearn/util/serialization/model_pickler.py
+++ b/src/squlearn/util/serialization/model_pickler.py
@@ -1,0 +1,35 @@
+import dill
+from squlearn.util.executor import Executor
+
+
+class ExecutorPickler(dill.Pickler):
+    """
+    Custom Pickler to handle the :ref:`Executor` object.
+    When an :ref:`Executor` is encountered, it will not be serialized directly.
+    Instead, it will return a marker that can be used to reconstruct the :ref:`Executor` later.
+    """
+
+    def __init__(self, file):
+        super().__init__(file)
+
+    def persistent_id(self, obj):
+        if isinstance(obj, Executor):
+            return ("EXECUTOR", None)
+        return None
+
+
+class ExecutorUnpickler(dill.Unpickler):
+    """
+    Custom Unpickler to handle the :ref:`Executor` object.
+    When a marker for an :ref:`Executor` is encountered, it will return the :ref:`Executor` instance that was provided during initialization.
+    """
+
+    def __init__(self, file, executor: Executor):
+        super().__init__(file)
+        self._executor = executor
+
+    def persistent_load(self, pid):
+        type_tag, _ = pid
+        if type_tag == "EXECUTOR":
+            return self._executor
+        return super().persistent_load(pid)

--- a/src/squlearn/util/serialization/model_pickler.py
+++ b/src/squlearn/util/serialization/model_pickler.py
@@ -13,6 +13,12 @@ class ExecutorPickler(dill.Pickler):
         super().__init__(file)
 
     def persistent_id(self, obj):
+        """
+        This method is called when an object is being serialized.
+        If the object is an instance of :ref:`Executor`, it returns a marker that can be used to reconstruct the :ref:`Executor` later.
+        Otherwise, it returns None, allowing the default serialization behavior to take place.
+        """
+
         if isinstance(obj, Executor):
             return ("EXECUTOR", None)
         return None
@@ -29,6 +35,12 @@ class ExecutorUnpickler(dill.Unpickler):
         self._executor = executor
 
     def persistent_load(self, pid):
+        """
+        This method is called when an object is being deserialized.
+        If the persistent ID indicates that it is an :ref:`Executor`, it returns the :ref:`Executor` instance.
+        Otherwise, it calls the superclass method to handle the default deserialization behavior.
+        """
+
         type_tag, _ = pid
         if type_tag == "EXECUTOR":
             return self._executor

--- a/src/squlearn/util/serialization/model_pickler.py
+++ b/src/squlearn/util/serialization/model_pickler.py
@@ -1,6 +1,8 @@
 import dill
 from squlearn.util.executor import Executor
 
+EXECUTOR_ID = "squlearn.util.executor"
+
 
 class ExecutorPickler(dill.Pickler):
     """
@@ -20,7 +22,7 @@ class ExecutorPickler(dill.Pickler):
         """
 
         if isinstance(obj, Executor):
-            return ("EXECUTOR", None)
+            return (EXECUTOR_ID, None)
         return None
 
 
@@ -42,6 +44,6 @@ class ExecutorUnpickler(dill.Unpickler):
         """
 
         type_tag, _ = pid
-        if type_tag == "EXECUTOR":
+        if type_tag == EXECUTOR_ID:
             return self._executor
         return super().persistent_load(pid)

--- a/src/squlearn/util/serialization/serializable_model_mixin.py
+++ b/src/squlearn/util/serialization/serializable_model_mixin.py
@@ -1,8 +1,36 @@
+from contextlib import contextmanager
+from io import IOBase
 from typing import IO, Type, TypeVar, Union
 from squlearn.util.serialization.model_pickler import ExecutorPickler, ExecutorUnpickler
 from squlearn.util.executor import Executor
 
 T = TypeVar("T", bound="SerializableModelMixin")
+
+
+@contextmanager
+def open_maybe(path_or_buf: Union[str, IO[bytes]], mode="rb"):
+    """
+    Context manager to handle opening a file or using an existing file-like object.
+    Args:
+        path_or_buf (Union[str, IO[bytes]]): A file path as a string or an IOBase object.
+        mode (str): The mode in which to open the file, default is "rb"
+    Yields:
+        An opened file object or the provided IOBase object.
+    Raises:
+        TypeError: If the provided path_or_buf is neither a string nor an IOBase object
+    """
+
+    if isinstance(path_or_buf, str):
+        f = open(path_or_buf, mode)
+        try:
+            yield f
+        finally:
+            f.close()
+    elif isinstance(path_or_buf, IOBase):
+        # already a proper stream
+        yield path_or_buf
+    else:
+        raise TypeError(f"Expected file path or IOBase, got {type(path_or_buf)}")
 
 
 class SerializableModelMixin:
@@ -18,18 +46,11 @@ class SerializableModelMixin:
             target (Union[str, IO[bytes]]): The target file path or file-like object where the model will be serialized.
         """
 
-        if hasattr(target, "write"):
-            # file-like object
-            pickler = ExecutorPickler(target)
-            pickler.dump(self)
-        else:
-            # path
-            with open(target, "wb") as f:
-                pickler = ExecutorPickler(f)
-                pickler.dump(self)
+        with open_maybe(target, "wb") as f:
+            ExecutorPickler(f).dump(self)
 
     @classmethod
-    def load(cls: Type[T], source, executor: Executor) -> T:
+    def load(cls: Type[T], source: Union[str, IO[bytes]], executor: Executor) -> T:
         """
         Deserializes the model object from a file or file-like object, injecting the provided :ref:`Executor`.
         Args:
@@ -38,11 +59,6 @@ class SerializableModelMixin:
         Returns:
             The deserialized model object with the injected :ref:`Executor`.
         """
-        # path
-        if isinstance(source, str):
-            with open(source, "rb") as f:
-                obj = ExecutorUnpickler(f, executor).load()
-        # file-like object
-        else:
-            obj = ExecutorUnpickler(source, executor).load()
-        return obj
+
+        with open_maybe(source, "rb") as f:
+            return ExecutorUnpickler(f, executor).load()

--- a/src/squlearn/util/serialization/serializable_model_mixin.py
+++ b/src/squlearn/util/serialization/serializable_model_mixin.py
@@ -1,0 +1,48 @@
+from typing import IO, Type, TypeVar, Union
+from squlearn.util.serialization.model_pickler import ExecutorPickler, ExecutorUnpickler
+from squlearn.util.executor import Executor
+
+T = TypeVar("T", bound="SerializableModelMixin")
+
+
+class SerializableModelMixin:
+    """A mixin class that provides serialization and deserialization capabilities for model objects.
+    This class uses :ref:`ExecutorPickler` and :ref:`ExecutorUnpickler` to handle the serialization of model objects
+    while ensuring that the :ref:`Executor` instance is properly injected during deserialization.
+    """
+
+    def dump(self, target: Union[str, IO[bytes]]) -> None:
+        """
+        Serializes the model object to a file or file-like object.
+        Args:
+            target (Union[str, IO[bytes]]): The target file path or file-like object where the model will be serialized.
+        """
+
+        if hasattr(target, "write"):
+            # file-like object
+            pickler = ExecutorPickler(target)
+            pickler.dump(self)
+        else:
+            # path
+            with open(target, "wb") as f:
+                pickler = ExecutorPickler(f)
+                pickler.dump(self)
+
+    @classmethod
+    def load(cls: Type[T], source, executor: Executor) -> T:
+        """
+        Deserializes the model object from a file or file-like object, injecting the provided :ref:`Executor`.
+        Args:
+            source (Union[str, IO[bytes]]): The source file path or file-like object from which the model will be deserialized.
+            executor (Executor): The :ref:`Executor` instance to be injected into the deserialized model.
+        Returns:
+            The deserialized model object with the injected :ref:`Executor`.
+        """
+        # path
+        if isinstance(source, str):
+            with open(source, "rb") as f:
+                obj = ExecutorUnpickler(f, executor).load()
+        # file-like object
+        else:
+            obj = ExecutorUnpickler(source, executor).load()
+        return obj

--- a/tests/kernel/ml/test_qgpr.py
+++ b/tests/kernel/ml/test_qgpr.py
@@ -1,11 +1,13 @@
 """Tests for QGPR"""
 
+import io
 import pytest
 import numpy as np
 from unittest.mock import MagicMock
 
 from sklearn.datasets import make_regression
 from sklearn.preprocessing import MinMaxScaler
+from sympy import E
 
 from squlearn import Executor
 from squlearn.encoding_circuit import YZ_CX_EncodingCircuit
@@ -25,7 +27,7 @@ class TestQGPR:
         X = scl.fit_transform(X, y)
         return X, y
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture
     def qgpr_fidelity(self) -> QGPR:
         """QGPR module with FidelityKernel."""
         np.random.seed(42)
@@ -34,7 +36,7 @@ class TestQGPR:
         kernel = FidelityKernel(encoding_circuit=encoding_circuit, executor=executor)
         return QGPR(quantum_kernel=kernel, sigma=1.0e-6)
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture
     def qgpr_pqk(self) -> QGPR:
         """QGPR module with ProjectedQuantumKernel."""
         np.random.seed(42)
@@ -214,3 +216,22 @@ class TestQGPR:
         qgpr_instance.predict(X)
 
         assert qgpr_instance._quantum_kernel._regularize_matrix.call_count == 3
+
+    @pytest.mark.parametrize("qgpr", ["qgpr_fidelity", "qgpr_pqk"])
+    def test_serialization(self, qgpr, request, data):
+        """Tests serialization of QGPR."""
+        instance = request.getfixturevalue(qgpr)
+        X, y = data
+        instance.fit(X, y)
+
+        buffer = io.BytesIO()
+        instance.dump(buffer)
+
+        predict_before = instance.predict(X)
+
+        buffer.seek(0)
+        instance_loaded = QGPR.load(buffer, Executor())
+        predict_after = instance_loaded.predict(X)
+
+        assert isinstance(instance_loaded, QGPR)
+        assert np.allclose(predict_before, predict_after, atol=1e-6)

--- a/tests/kernel/ml/test_qsvc.py
+++ b/tests/kernel/ml/test_qsvc.py
@@ -1,5 +1,6 @@
 """Tests for QSVC"""
 
+import io
 import pytest
 import numpy as np
 from unittest.mock import MagicMock
@@ -26,7 +27,7 @@ class TestQSVC:
         X = scl.fit_transform(X, y)
         return X, y
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture
     def qsvc_fidelity(self) -> QSVC:
         """QSVC module with FidelityKernel."""
         np.random.seed(42)
@@ -40,7 +41,7 @@ class TestQSVC:
         )
         return QSVC(kernel)
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture
     def qsvc_pqk(self) -> QSVC:
         """QSVC module wit ProjectedQuantumKernel."""
         np.random.seed(42)
@@ -198,3 +199,22 @@ class TestQSVC:
         qsvc_instance.predict(X)
 
         assert qsvc_instance.quantum_kernel._regularize_matrix.call_count == 2
+
+    @pytest.mark.parametrize("qsvc", ["qsvc_fidelity", "qsvc_pqk"])
+    def test_serialization(self, qsvc, request, data):
+        """Tests serialization of QSVC."""
+        instance = request.getfixturevalue(qsvc)
+        X, y = data
+        instance.fit(X, y)
+
+        buffer = io.BytesIO()
+        instance.dump(buffer)
+
+        predict_before = instance.predict(X)
+
+        buffer.seek(0)
+        instance_loaded = QSVC.load(buffer, Executor())
+        predict_after = instance_loaded.predict(X)
+
+        assert isinstance(instance_loaded, QSVC)
+        assert np.allclose(predict_before, predict_after, atol=1e-6)

--- a/tests/kernel/ml/test_qsvr.py
+++ b/tests/kernel/ml/test_qsvr.py
@@ -1,5 +1,6 @@
 """Tests for QSVR"""
 
+import io
 import pytest
 import numpy as np
 from unittest.mock import MagicMock
@@ -26,7 +27,7 @@ class TestQSVR:
         X = scl.fit_transform(X, y)
         return X, y
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture
     def qsvr_fidelity(self) -> QSVR:
         """QSVR module with FidelityKernel."""
         np.random.seed(42)
@@ -40,7 +41,7 @@ class TestQSVR:
         )
         return QSVR(kernel, C=1, epsilon=0.1)
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture
     def qsvr_pqk(self) -> QSVR:
         """QSVR module wit ProjectedQuantumKernel."""
         np.random.seed(42)
@@ -197,3 +198,22 @@ class TestQSVR:
         qsvr_instance.predict(X)
 
         assert qsvr_instance.quantum_kernel._regularize_matrix.call_count == 2
+
+    @pytest.mark.parametrize("qsvr", ["qsvr_fidelity", "qsvr_pqk"])
+    def test_serialization(self, qsvr, request, data):
+        """Tests serialization of QSVR."""
+        instance = request.getfixturevalue(qsvr)
+        X, y = data
+        instance.fit(X, y)
+
+        buffer = io.BytesIO()
+        instance.dump(buffer)
+
+        predict_before = instance.predict(X)
+
+        buffer.seek(0)
+        instance_loaded = QSVR.load(buffer, Executor())
+        predict_after = instance_loaded.predict(X)
+
+        assert isinstance(instance_loaded, QSVR)
+        assert np.allclose(predict_before, predict_after, atol=1e-6)

--- a/tests/qnn/test_qnnc.py
+++ b/tests/qnn/test_qnnc.py
@@ -1,5 +1,6 @@
 """Tests for QNNClassifier"""
 
+import io
 import pytest
 
 import numpy as np
@@ -201,3 +202,20 @@ class TestQNNClassifier:
         assert qnn_classifier._is_fitted
         assert not np.allclose(qnn_classifier.param, qnn_classifier.param_ini)
         assert not np.allclose(qnn_classifier.param_op, qnn_classifier.param_op_ini)
+
+    def test_serialization(self, qnn_classifier, request, data):
+        """Tests concerning the serialization of the QNNClassifier."""
+        X, y = data
+        qnn_classifier.fit(X, y)
+
+        buffer = io.BytesIO()
+        qnn_classifier.dump(buffer)
+
+        predict_before = qnn_classifier.predict(X)
+
+        buffer.seek(0)
+        instance_loaded = QNNClassifier.load(buffer, Executor())
+        predict_after = instance_loaded.predict(X)
+
+        assert isinstance(instance_loaded, QNNClassifier)
+        assert np.allclose(predict_before, predict_after, atol=1e-6)

--- a/tests/qnn/test_qnnr.py
+++ b/tests/qnn/test_qnnr.py
@@ -1,5 +1,6 @@
 """Tests for QNNRegressor"""
 
+import io
 import pytest
 
 import numpy as np
@@ -204,3 +205,21 @@ class TestQNNRegressor:
         assert qnn_regressor._is_fitted
         assert not np.allclose(qnn_regressor.param, qnn_regressor.param_ini)
         assert not np.allclose(qnn_regressor.param_op, qnn_regressor.param_op_ini)
+
+    def test_serialization(self, qnn_regressor, request, data):
+        """Tests concerning the serialization of the QNNRegressor."""
+
+        X, y = data
+        qnn_regressor.fit(X, y)
+
+        buffer = io.BytesIO()
+        qnn_regressor.dump(buffer)
+
+        predict_before = qnn_regressor.predict(X)
+
+        buffer.seek(0)
+        instance_loaded = QNNRegressor.load(buffer, Executor())
+        predict_after = instance_loaded.predict(X)
+
+        assert isinstance(instance_loaded, QNNRegressor)
+        assert np.allclose(predict_before, predict_after, atol=1e-6)

--- a/tests/util/serialization/test_model_pickler.py
+++ b/tests/util/serialization/test_model_pickler.py
@@ -75,3 +75,12 @@ def test_multiple_executor_references(executor_obj):
     loaded = holder.load(buffer, executor_obj)
     assert loaded.level1.executor is executor_obj
     assert loaded.level2.executor is executor_obj
+
+
+def test_invalid_path_or_buf():
+    with pytest.raises(TypeError):
+        SerializableModelMixin.load(123, Executor("pennylane"))  # Invalid type for source
+    with pytest.raises(TypeError):
+        SerializableModelMixin.dump(123)  # Invalid type for target
+    with pytest.raises(TypeError):
+        SerializableModelMixin.dump(None)  # None is not a valid path or buffer

--- a/tests/util/serialization/test_model_pickler.py
+++ b/tests/util/serialization/test_model_pickler.py
@@ -1,0 +1,77 @@
+import io
+import dill
+import pytest
+
+from squlearn.util.executor import Executor
+from squlearn.util.serialization.serializable_model_mixin import SerializableModelMixin
+
+
+class DummyExecutorHolder(SerializableModelMixin):
+    def __init__(self, executor):
+        self.executor = executor
+
+
+class DummyUnpickler(dill.Unpickler):
+    def persistent_load(self, pid):
+        return None
+
+
+@pytest.fixture
+def executor_obj():
+    return Executor("pennylane")
+
+
+def test_executor_removed_by_pickler(executor_obj):
+    dummy = DummyExecutorHolder(executor_obj)
+
+    buffer = io.BytesIO()
+    dummy.dump(buffer)
+
+    # raw load with dill, which should ignore the persistent IDs
+    buffer.seek(0)
+    dummpy_pickler = DummyUnpickler(buffer)
+    raw = dummpy_pickler.load()
+
+    assert hasattr(raw, "executor")
+    assert raw.executor is None
+
+
+def test_executor_reinjected_by_unpickler(executor_obj):
+    dummy = DummyExecutorHolder(executor_obj)
+
+    # Dump via ExecutorPickler
+    buffer = io.BytesIO()
+    dummy.dump(buffer)
+
+    # unpickle with ExecutorUnpickler => executor should be injected
+    buffer.seek(0)
+    loaded = dummy.load(buffer, executor_obj)
+
+    assert hasattr(loaded, "executor")
+    assert loaded.executor is executor_obj
+
+
+def test_multiple_executor_references(executor_obj):
+    class Holder(SerializableModelMixin):
+        def __init__(self, executor):
+            self.level1 = DummyExecutorHolder(executor)
+            self.level2 = DummyExecutorHolder(executor)
+
+    holder = Holder(executor_obj)
+
+    buffer = io.BytesIO()
+    holder.dump(buffer)
+
+    # raw load all executor references should be None
+    buffer.seek(0)
+    dummy_pickler = DummyUnpickler(buffer)
+    raw = dummy_pickler.load()
+    assert raw.level1.executor is None
+    assert raw.level2.executor is None
+
+    # load with ExecutorUnpickler, which should reinject the executor
+    buffer.seek(0)
+
+    loaded = holder.load(buffer, executor_obj)
+    assert loaded.level1.executor is executor_obj
+    assert loaded.level2.executor is executor_obj


### PR DESCRIPTION
## Changes Made
Introduce a custom serialization layer for QML models that cleanly strips out the `Executor` during pickling and re‑injects it on unpickling. This is achieved via:

### 1. `ExecutorPickler` / `ExecutorUnpickler`
- Uses Dill’s `persistent_id` / `persistent_load` hooks
- Replaces any `Executor` instance with a lightweight marker in the serialized stream
- Restores the actual `Executor` object at load time

### 2. `open_maybe` context manager
- Unifies file‑path and file‑like support
- Ensures correct opening/closing for disk files while allowing in‑memory streams

### 3. `SerializableModelMixin`
- Exposes `dump(target)` and `load(source, executor)` methods on any model
- Internally uses the custom pickler/unpickler and `open_maybe`
- Can be mixed into all existing model classes for seamless support

closes #275 