### PR TITLE
Add break condition choice to adam minimize

### DIFF
--- a/src/squlearn/optimizers/adam.py
+++ b/src/squlearn/optimizers/adam.py
@@ -12,7 +12,7 @@ class Adam(OptimizerBase, SGDMixin):
     Possible options that can be set in the options dictionary are:
 
     * **tol** (float): Tolerance for the termination of the optimization (default: 1e-6)
-    * **condition** (str): Break when parameter update is below tol ('param_update') or when
+    * **break_condition** (str): Break when parameter update is below tol ('param_update') or when
       the function value ('func_value') goes below tol (default: 'param_update')
     * **lr** (float, list, np.ndarray, callable): Learning rate. If float, the learning rate is constant.
       If list or np.ndarray, the learning rate is taken from the list or array.
@@ -39,9 +39,9 @@ class Adam(OptimizerBase, SGDMixin):
             options = {}
 
         self.tol = options.get("tol", 1e-6)
-        self.condition = options.get("condition", "param_update")
-        if self.condition not in ["param_update", "func_value"]:
-            raise ValueError("Condition must be 'param_update' or 'func_value'.")
+        self.break_condition = options.get("break_condition", "param_update")
+        if self.break_condition not in ["param_update", "func_value"]:
+            raise ValueError("Break condition must be 'param_update' or 'func_value'.")
         self.lr = options.get("lr", 0.05)
         self.beta_1 = options.get("beta_1", 0.9)
         self.beta_2 = options.get("beta_2", 0.99)
@@ -146,7 +146,7 @@ class Adam(OptimizerBase, SGDMixin):
                 self.callback(self.iteration, self.x, gradient, fval)
 
             # check termination
-            if self.condition == "func_value":  # func_value
+            if self.break_condition == "func_value":  # func_value
                 if fval is not None and fval < self.tol:
                     break
             else:  # param_update


### PR DESCRIPTION
This PR allows to choose the break condition for the `Adam` optimizer's `minimize` function between
- `param_update` to break when the parameter update is below tol, which is the old behavior and the default
- `func_value` to break when the func value goes below tol

maxiter and maxiter_total will be kept in both cases.