### PR TITLE
Fix LowLevelQNNPennyLane output shape

### DIFF
--- a/src/squlearn/qnn/lowlevel_qnn/lowlevel_qnn_pennylane.py
+++ b/src/squlearn/qnn/lowlevel_qnn/lowlevel_qnn_pennylane.py
@@ -498,7 +498,14 @@ class LowLevelQNNPennyLane(LowLevelQNNBase):
             value = self._executor.pennylane_execute(deriv, *(eval_tuple))
 
         # Convert back to numpy array
-        return np.real_if_close(np.array(value))
+        values = np.array(value)
+        # PennyLane collapses the leading "observable" axis when a multi-output
+        # QNN has only one observable. Restore it so downstream shape logic
+        # (swap_list in _evaluate) sees the (num_obs, ...) layout consistent
+        # with the multi-observable case.
+        if self.multiple_output and self.num_operator == 1:
+            values = values.reshape((1,) + values.shape)
+        return np.real_if_close(values)
 
     def _evaluate_todo_all_x(
         self, todo_class: DirectEvaluation, x: np.array, param: np.array, param_obs: np.array
@@ -584,6 +591,13 @@ class LowLevelQNNPennyLane(LowLevelQNNBase):
 
         # Convert back to numpy format
         values = np.array(value)
+        # PennyLane collapses the leading "observable" axis when a multi-output
+        # QNN has only one observable. Restore it so the sum_t bookkeeping below
+        # (which assumes ioff=1 for multiple_output) and the downstream swap_list
+        # in _evaluate see the (num_obs, ...) layout consistent with the
+        # multi-observable case.
+        if self.multiple_output and self.num_operator == 1:
+            values = values.reshape((1,) + values.shape)
         # sum over zero values entries due to dx differentiation
         if todo_class.return_grad_x:
             sum_t = tuple()

--- a/tests/qnn/lowlevel_qnn/test_lowlevel_qnn.py
+++ b/tests/qnn/lowlevel_qnn/test_lowlevel_qnn.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from squlearn import Executor
 from squlearn.encoding_circuit import ParamZFeatureMap
-from squlearn.observables import SummedPaulis
+from squlearn.observables import SinglePauli, SummedPaulis
 from squlearn.qnn.lowlevel_qnn import LowLevelQNN
 
 
@@ -63,3 +63,28 @@ def test_backends_consistency():
         values_qiskit[qiskit_param_op_key], values_pennylane[pennylane_param_op_key]
     )
     assert np.allclose(values_qiskit[qiskit_param_op_key], values_qulacs[qulacs_param_op_key])
+
+
+@pytest.mark.parametrize("framework", ["pennylane", "qiskit", "qulacs"])
+@pytest.mark.parametrize("n_obs", [1, 2])
+def test_multiple_output_shape_with_n_observables(framework, n_obs):
+    """Regression: a list-of-one observable must produce the same shape contract
+    as a list of multiple observables. PennyLane otherwise collapses the leading
+    "observable" axis when only one measurement is returned, which previously
+    crashed ProjectedQuantumKernel for num_qubits=1 with a single-Pauli measurement.
+    """
+    pqc = ParamZFeatureMap(4, 2)
+    obs = [SinglePauli(4, i, op_str="X") for i in range(n_obs)]
+    llqnn = LowLevelQNN(pqc, obs, executor=Executor(framework), num_features=2)
+
+    np.random.seed(42)
+    x = np.random.rand(5, 2)
+    param = np.random.rand(llqnn.num_parameters)
+
+    assert llqnn.evaluate(x, param, [], "f")["f"].shape == (5, n_obs)
+    assert llqnn.evaluate(x, param, [], "dfdx")["dfdx"].shape == (5, n_obs, 2)
+    assert llqnn.evaluate(x, param, [], "dfdp")["dfdp"].shape == (
+        5,
+        n_obs,
+        llqnn.num_parameters,
+    )


### PR DESCRIPTION
When a single Observable wrapped in a List is used (for example from `ProjectedQuantumKernel`), PennyLane collapses the axis which leads to errors in the optimization. This PR patches this.