### PR TITLE
auto-disable opt_param_op

### DIFF
--- a/src/squlearn/qnn/base_qnn.py
+++ b/src/squlearn/qnn/base_qnn.py
@@ -118,6 +118,7 @@ class BaseQNN(BaseEstimator, SerializableModelMixin, ABC):
         self.shuffle = shuffle
 
         self.opt_param_op = opt_param_op
+        self._maybe_disable_opt_param_op()
 
         self.caching = caching
         self.pretrained = pretrained
@@ -301,7 +302,32 @@ class BaseQNN(BaseEstimator, SerializableModelMixin, ABC):
         self._is_fitted = False
         self._is_lowlevel_qnn_initialized = not initialize_qnn
 
+        self._maybe_disable_opt_param_op()
+
         return self
+
+    def _maybe_disable_opt_param_op(self) -> None:
+        """Force ``opt_param_op`` off when the observable has no trainable params.
+
+        Optimizing zero parameters is a no-op. Worse, for multi-output QNNs
+        (operator passed as a list), letting the training loop request
+        ``dfdop`` returns an empty (1, 0) sentinel from
+        ``LowLevelQNNPennyLane._evaluate_todo_all_x`` that downstream
+        ``_evaluate`` cannot reshape, crashing with
+        ``ValueError: cannot reshape array of size 0 into shape (k, 1)``.
+
+        Only the ``True -> False`` direction is auto-applied; if the user
+        explicitly disabled observable-parameter optimization, that choice is
+        respected even if the observable does have trainable parameters.
+        """
+        if not self.opt_param_op:
+            return
+        if isinstance(self.operator, list):
+            num_op_parameters = sum(op.num_parameters for op in self.operator)
+        else:
+            num_op_parameters = self.operator.num_parameters
+        if num_op_parameters == 0:
+            self.opt_param_op = False
 
     def _predict(self, X: np.ndarray) -> np.ndarray:
         """Predict using the QNN.

--- a/tests/qnn/test_qnnc.py
+++ b/tests/qnn/test_qnnc.py
@@ -251,9 +251,7 @@ class TestQNNClassifier:
         path where the bug originally surfaced.
         """
         kwargs = dict(
-            encoding_circuit=ChebyshevPQC(
-                num_qubits=2, num_features=2, num_layers=2
-            ),
+            encoding_circuit=ChebyshevPQC(num_qubits=2, num_features=2, num_layers=2),
             operator=operator,
             executor=Executor("pennylane"),
             loss=SquaredLoss(),
@@ -266,10 +264,14 @@ class TestQNNClassifier:
         kwargs.update(overrides)
         return QNNClassifier(**kwargs)
 
-    @pytest.mark.parametrize("operator", [
-        [SinglePauli(2, 0, op_str="X")],
-        [SinglePauli(2, 0, op_str="X"), SinglePauli(2, 1, op_str="X")],
-    ], ids=["list_of_1", "list_of_2"])
+    @pytest.mark.parametrize(
+        "operator",
+        [
+            [SinglePauli(2, 0, op_str="X")],
+            [SinglePauli(2, 0, op_str="X"), SinglePauli(2, 1, op_str="X")],
+        ],
+        ids=["list_of_1", "list_of_2"],
+    )
     def test_opt_param_op_auto_disabled_at_init(self, data, operator):
         """Regression: ``opt_param_op`` auto-flips to ``False`` at construction
         when the observable has no trainable parameters.
@@ -295,9 +297,7 @@ class TestQNNClassifier:
         """Observable has trainable params, but user explicitly opted out:
         auto-correction must only ever flip ``True -> False``, never the
         other direction."""
-        qnnc = self._make_opt_param_op_qnnc(
-            SummedPaulis(num_qubits=2), opt_param_op=False
-        )
+        qnnc = self._make_opt_param_op_qnnc(SummedPaulis(num_qubits=2), opt_param_op=False)
         assert qnnc.opt_param_op is False
 
     def test_opt_param_op_re_evaluates_in_set_params(self):

--- a/tests/qnn/test_qnnc.py
+++ b/tests/qnn/test_qnnc.py
@@ -8,10 +8,10 @@ from sklearn.datasets import make_blobs
 from sklearn.preprocessing import LabelBinarizer, MinMaxScaler
 
 from squlearn import Executor
-from squlearn.observables import SummedPaulis
+from squlearn.observables import SinglePauli, SummedPaulis
 from squlearn.encoding_circuit import ChebyshevPQC
 from squlearn.optimizers import SLSQP, Adam
-from squlearn.qnn import CrossEntropyLoss, QNNClassifier
+from squlearn.qnn import CrossEntropyLoss, QNNClassifier, SquaredLoss
 
 
 class TestQNNClassifier:
@@ -240,3 +240,71 @@ class TestQNNClassifier:
         assert instance_loaded._is_fitted
         assert np.allclose(instance_loaded.param, qnn_classifier.param)
         assert np.allclose(instance_loaded.param_op, qnn_classifier.param_op)
+
+    def _make_opt_param_op_qnnc(self, operator, **overrides) -> QNNClassifier:
+        """QNNClassifier with a parameterless-observable-friendly setup.
+
+        Used by the ``opt_param_op`` auto-correction regression tests below.
+        ``ChebyshevPQC`` carries trainable circuit params (so training would
+        request ``dfdp`` and reach the empty-``dfdop`` early-return on the
+        PennyLane backend), and ``Adam`` exercises the SGD/``train_mini_batch``
+        path where the bug originally surfaced.
+        """
+        kwargs = dict(
+            encoding_circuit=ChebyshevPQC(
+                num_qubits=2, num_features=2, num_layers=2
+            ),
+            operator=operator,
+            executor=Executor("pennylane"),
+            loss=SquaredLoss(),
+            optimizer=Adam(options={"lr": 0.05}),
+            batch_size=5,
+            epochs=1,
+            shuffle=False,
+            parameter_seed=0,
+        )
+        kwargs.update(overrides)
+        return QNNClassifier(**kwargs)
+
+    @pytest.mark.parametrize("operator", [
+        [SinglePauli(2, 0, op_str="X")],
+        [SinglePauli(2, 0, op_str="X"), SinglePauli(2, 1, op_str="X")],
+    ], ids=["list_of_1", "list_of_2"])
+    def test_opt_param_op_auto_disabled_at_init(self, data, operator):
+        """Regression: ``opt_param_op`` auto-flips to ``False`` at construction
+        when the observable has no trainable parameters.
+
+        Otherwise training requests ``dfdop`` and crashes with
+        ``ValueError: cannot reshape array of size 0 into shape (k, 1)`` for
+        any multi-output QNN (operator passed as a list).
+        """
+        qnnc = self._make_opt_param_op_qnnc(operator)
+        assert qnnc.opt_param_op is False  # at __init__, not deferred to fit
+        X, y = data
+        qnnc.fit(X, y)
+        assert qnnc.predict(X).shape == y.shape
+
+    def test_opt_param_op_left_alone_when_obs_has_params(self, data):
+        qnnc = self._make_opt_param_op_qnnc(SummedPaulis(num_qubits=2))
+        assert qnnc.opt_param_op is True
+        X, y = data
+        qnnc.fit(X, y)
+        assert qnnc.opt_param_op is True
+
+    def test_opt_param_op_explicit_false_is_respected(self):
+        """Observable has trainable params, but user explicitly opted out:
+        auto-correction must only ever flip ``True -> False``, never the
+        other direction."""
+        qnnc = self._make_opt_param_op_qnnc(
+            SummedPaulis(num_qubits=2), opt_param_op=False
+        )
+        assert qnnc.opt_param_op is False
+
+    def test_opt_param_op_re_evaluates_in_set_params(self):
+        """Swap a parameterized observable for one with no params via
+        ``set_params``: ``opt_param_op`` must re-evaluate immediately, not
+        wait for the next ``fit``."""
+        qnnc = self._make_opt_param_op_qnnc(SummedPaulis(num_qubits=2))
+        assert qnnc.opt_param_op is True
+        qnnc.set_params(operator=[SinglePauli(2, 0, op_str="X")])
+        assert qnnc.opt_param_op is False

--- a/tests/qnn/test_qnnr.py
+++ b/tests/qnn/test_qnnr.py
@@ -8,10 +8,10 @@ from sklearn.datasets import make_regression
 from sklearn.preprocessing import MinMaxScaler
 
 from squlearn import Executor
-from squlearn.observables import SummedPaulis
-from squlearn.encoding_circuit import ChebyshevRx
+from squlearn.observables import SinglePauli, SummedPaulis
+from squlearn.encoding_circuit import ChebyshevPQC, ChebyshevRx
 from squlearn.optimizers import SLSQP, Adam
-from squlearn.qnn import QNNRegressor, MeanSquaredError
+from squlearn.qnn import QNNRegressor, MeanSquaredError, SquaredLoss
 
 
 class TestQNNRegressor:
@@ -241,3 +241,74 @@ class TestQNNRegressor:
         assert instance_loaded._is_fitted
         assert np.allclose(instance_loaded.param, qnn_regressor.param)
         assert np.allclose(instance_loaded.param_op, qnn_regressor.param_op)
+
+    def _make_opt_param_op_qnnr(self, operator, **overrides) -> QNNRegressor:
+        """QNNRegressor with a parameterless-observable-friendly setup.
+
+        Used by the ``opt_param_op`` auto-correction regression tests below.
+        ``ChebyshevPQC`` carries trainable circuit params (so training would
+        request ``dfdp`` and reach the empty-``dfdop`` early-return on the
+        PennyLane backend), and ``Adam`` exercises the SGD/``train_mini_batch``
+        path where the bug originally surfaced.
+        """
+        kwargs = dict(
+            encoding_circuit=ChebyshevPQC(
+                num_qubits=2, num_features=1, num_layers=2
+            ),
+            operator=operator,
+            executor=Executor("pennylane"),
+            loss=SquaredLoss(),
+            optimizer=Adam(options={"lr": 0.05}),
+            batch_size=3,
+            epochs=1,
+            shuffle=False,
+            parameter_seed=0,
+        )
+        kwargs.update(overrides)
+        return QNNRegressor(**kwargs)
+
+    @pytest.mark.parametrize("operator", [
+        [SinglePauli(2, 0, op_str="X")],
+        [SinglePauli(2, 0, op_str="X"), SinglePauli(2, 1, op_str="X")],
+    ], ids=["list_of_1", "list_of_2"])
+    def test_opt_param_op_auto_disabled_at_init(self, data, operator):
+        """Regression: ``opt_param_op`` auto-flips to ``False`` at construction
+        when the observable has no trainable parameters.
+
+        Otherwise training requests ``dfdop`` and crashes with
+        ``ValueError: cannot reshape array of size 0 into shape (k, 1)`` for
+        any multi-output QNN (operator passed as a list).
+        """
+        qnnr = self._make_opt_param_op_qnnr(operator)
+        assert qnnr.opt_param_op is False  # at __init__, not deferred to fit
+        X, y = data
+        # Multi-output regression needs y with matching shape; broadcast the
+        # 1D target across the observable list so fit doesn't fail upstream.
+        y_multi = np.broadcast_to(y[:, None], (y.shape[0], len(operator)))
+        qnnr.fit(X, y_multi)
+        assert qnnr.predict(X).shape == y_multi.shape
+
+    def test_opt_param_op_left_alone_when_obs_has_params(self, data):
+        qnnr = self._make_opt_param_op_qnnr(SummedPaulis(num_qubits=2))
+        assert qnnr.opt_param_op is True
+        X, y = data
+        qnnr.fit(X, y)
+        assert qnnr.opt_param_op is True
+
+    def test_opt_param_op_explicit_false_is_respected(self):
+        """Observable has trainable params, but user explicitly opted out:
+        auto-correction must only ever flip ``True -> False``, never the
+        other direction."""
+        qnnr = self._make_opt_param_op_qnnr(
+            SummedPaulis(num_qubits=2), opt_param_op=False
+        )
+        assert qnnr.opt_param_op is False
+
+    def test_opt_param_op_re_evaluates_in_set_params(self):
+        """Swap a parameterized observable for one with no params via
+        ``set_params``: ``opt_param_op`` must re-evaluate immediately, not
+        wait for the next ``fit``."""
+        qnnr = self._make_opt_param_op_qnnr(SummedPaulis(num_qubits=2))
+        assert qnnr.opt_param_op is True
+        qnnr.set_params(operator=[SinglePauli(2, 0, op_str="X")])
+        assert qnnr.opt_param_op is False

--- a/tests/qnn/test_qnnr.py
+++ b/tests/qnn/test_qnnr.py
@@ -252,9 +252,7 @@ class TestQNNRegressor:
         path where the bug originally surfaced.
         """
         kwargs = dict(
-            encoding_circuit=ChebyshevPQC(
-                num_qubits=2, num_features=1, num_layers=2
-            ),
+            encoding_circuit=ChebyshevPQC(num_qubits=2, num_features=1, num_layers=2),
             operator=operator,
             executor=Executor("pennylane"),
             loss=SquaredLoss(),
@@ -267,10 +265,14 @@ class TestQNNRegressor:
         kwargs.update(overrides)
         return QNNRegressor(**kwargs)
 
-    @pytest.mark.parametrize("operator", [
-        [SinglePauli(2, 0, op_str="X")],
-        [SinglePauli(2, 0, op_str="X"), SinglePauli(2, 1, op_str="X")],
-    ], ids=["list_of_1", "list_of_2"])
+    @pytest.mark.parametrize(
+        "operator",
+        [
+            [SinglePauli(2, 0, op_str="X")],
+            [SinglePauli(2, 0, op_str="X"), SinglePauli(2, 1, op_str="X")],
+        ],
+        ids=["list_of_1", "list_of_2"],
+    )
     def test_opt_param_op_auto_disabled_at_init(self, data, operator):
         """Regression: ``opt_param_op`` auto-flips to ``False`` at construction
         when the observable has no trainable parameters.
@@ -299,9 +301,7 @@ class TestQNNRegressor:
         """Observable has trainable params, but user explicitly opted out:
         auto-correction must only ever flip ``True -> False``, never the
         other direction."""
-        qnnr = self._make_opt_param_op_qnnr(
-            SummedPaulis(num_qubits=2), opt_param_op=False
-        )
+        qnnr = self._make_opt_param_op_qnnr(SummedPaulis(num_qubits=2), opt_param_op=False)
         assert qnnr.opt_param_op is False
 
     def test_opt_param_op_re_evaluates_in_set_params(self):


### PR DESCRIPTION
This pull request introduces an automatic mechanism in the QNN base class to disable observable-parameter optimization (`opt_param_op`) when the observable has no trainable parameters, preventing crashes during training. It also adds comprehensive regression tests for this behavior in both the classifier and regressor QNNs.

**Automatic disabling of `opt_param_op` for parameterless observables:**

* Added the `_maybe_disable_opt_param_op` method to `BaseQNN`, which automatically sets `opt_param_op` to `False` if the observable(s) have no trainable parameters. This is invoked during initialization and whenever parameters are set, ensuring the optimization logic is always consistent and preventing downstream errors. [[1]](diffhunk://#diff-0fb9ed0a6dfe395c621fb7a7ddf8dcf7f0243c6aa22fb0de1873116277a44c77R121) [[2]](diffhunk://#diff-0fb9ed0a6dfe395c621fb7a7ddf8dcf7f0243c6aa22fb0de1873116277a44c77R305-R331)

**Regression tests for `opt_param_op` behavior:**

* Added helper methods and new tests in `test_qnnc.py` and `test_qnnr.py` to verify that `opt_param_op` is auto-disabled at construction or when observables are swapped to parameterless ones, and that explicit user settings are respected. These tests cover both single and multiple observables, as well as the behavior during parameter changes. [[1]](diffhunk://#diff-17777d6631322d9b0b2a8f0a35341c138c495151b034dd97fee2bd283c0f70e5R243-R310) [[2]](diffhunk://#diff-0d8927d17ee1979448037bc43410d22fb7aba6ae25cc5b4a225f37f23fe2418aR244-R314)

**Test infrastructure improvements:**

* Extended test imports to include `SinglePauli` and `SquaredLoss`, and used `ChebyshevPQC` for encoding circuits to ensure the test cases exercise the relevant code paths. [[1]](diffhunk://#diff-17777d6631322d9b0b2a8f0a35341c138c495151b034dd97fee2bd283c0f70e5L11-R14) [[2]](diffhunk://#diff-0d8927d17ee1979448037bc43410d22fb7aba6ae25cc5b4a225f37f23fe2418aL11-R14)