### PR TITLE
Transpiled Circuit derivative

### DIFF
--- a/src/squlearn/encoding_circuit/encoding_circuit_derivatives.py
+++ b/src/squlearn/encoding_circuit/encoding_circuit_derivatives.py
@@ -92,6 +92,7 @@ class EncodingCircuitDerivatives:
         encoding_circuit: EncodingCircuitBase,
         num_features: int,
         optree_caching: bool = True,
+        backend = None
     ):
         self.encoding_circuit = encoding_circuit
 
@@ -101,7 +102,7 @@ class EncodingCircuitDerivatives:
         self._circuit = encoding_circuit.get_circuit(self._x, self._p)
 
         self._instruction_set = list(set(self._circuit.count_ops()))
-        self._circuit = OpTree.derivative.transpile_to_supported_instructions(self._circuit)
+        self._circuit = OpTree.derivative.transpile_to_supported_instructions(self._circuit, backend=backend)
 
         self._optree_start = OpTreeCircuit(self._circuit)
 

--- a/src/squlearn/qnn/lowlevel_qnn/lowlevel_qnn_qiskit.py
+++ b/src/squlearn/qnn/lowlevel_qnn/lowlevel_qnn_qiskit.py
@@ -459,7 +459,7 @@ class LowLevelQNNQiskit(LowLevelQNNBase):
             num_qubits_operator = self._observable.num_qubits
 
         self.operator_derivatives = ObservableDerivatives(self._observable)
-        self.pqc_derivatives = EncodingCircuitDerivatives(self._pqc, self._num_features)
+        self.pqc_derivatives = EncodingCircuitDerivatives(self._pqc, self._num_features, backend=self._executor.backend)
 
         if self._pqc.num_virtual_qubits != num_qubits_operator:
             raise ValueError("Number of Qubits are not the same!")

--- a/src/squlearn/util/optree/optree_derivative.py
+++ b/src/squlearn/util/optree/optree_derivative.py
@@ -371,7 +371,7 @@ class OpTreeDerivative:
 
     @staticmethod
     def transpile_to_supported_instructions(
-        circuit: QuantumCircuit, supported_gates: Set[str] = SUPPORTED_GATES
+        circuit: QuantumCircuit, supported_gates: Set[str] = SUPPORTED_GATES, backend=None
     ) -> QuantumCircuit:
         """Function for transpiling a circuit to a supported instruction set for gradient calculation.
 
@@ -385,12 +385,10 @@ class OpTreeDerivative:
 
         unique_ops = set(circuit.count_ops())
         if not unique_ops.issubset(supported_gates):
-            circuit = transpile(
-                circuit,
-                basis_gates=list(supported_gates),
-                optimization_level=0,
-                layout_method="trivial",
-            )
+            if backend is not None:
+                circuit = transpile(circuit, backend=backend, optimization_level=0, layout_method="trivial")
+            else:
+                circuit = transpile(circuit, basis_gates=list(supported_gates), optimization_level=0, layout_method="trivial")
         return circuit
 
     @staticmethod


### PR DESCRIPTION
Dear squlearn devs, 

thanks for the great library you are creating ! We are starting to use squlearn on IQM machines and we ran into some small issues. One of them is related to set of native gates statically defined [here](https://github.com/sQUlearn/squlearn/blob/0f6cb0982fdbe80dcd0ea6cb0acd68c59e362de4/src/squlearn/util/optree/optree_derivative.py#L352). Since IQM backends have a very limited set of native gates, this caused issues with qiskit runtime. 

To circumvent the issue, I've piped the backend info all the way to the optree class while trying to keep the original behavior as default.  It might be useful to also consider specifying the transpilation options a bit more dynamically and potentially use the TranspiledEncodingCircuit class instead of simply calling the transpile function.

If you think that's useful, I can put some more work into this as we need it for our project. However before doing so I would love to know what you think or if you see a simpler option to make squlearn compatible with IQM. 

Best wishes
Nico